### PR TITLE
Minor fixes and add JWKS URL parameter

### DIFF
--- a/cmd/smd/main.go
+++ b/cmd/smd/main.go
@@ -944,7 +944,7 @@ func main() {
 	if s.requireAuth {
 		s.LogAlways("Fetching public key from server...")
 		for i := 0; i <= 5; i++ {
-			err = s.loadPublicKeyFromURL(s.jwksURL)
+			err = s.fetchPublicKeyFromURL(s.jwksURL)
 			if err != nil {
 				s.LogAlways("failed to initialize auth token: %v", err)
 				time.Sleep(5 * time.Second)

--- a/cmd/smd/main.go
+++ b/cmd/smd/main.go
@@ -559,7 +559,7 @@ func (s *SmD) parseCmdLine() {
 	flag.StringVar(&s.dbHost, "dbhost", "", "Database hostname")
 	flag.StringVar(&s.dbPortStr, "dbport", "", "Database port")
 	flag.StringVar(&s.dbOpts, "dbopts", "", "Database options string")
-	flag.StringVar(&s.jwksURL, "jwks-url", "https://127.0.0.1/", "Set the JWKS URL to fetch public key for validation")
+	flag.StringVar(&s.jwksURL, "jwks-url", "https://127.0.0.1:9091/jwks.json", "Set the JWKS URL to fetch public key for validation")
 	flag.BoolVar(&applyMigrations, "migrate", false, "Apply all database migrations before starting")
 	flag.BoolVar(&s.disableDiscovery, "disable-discovery", false, "Disable discovery-related subroutines")
 	flag.BoolVar(&s.requireAuth, "require-auth", false, "Require JWT authorization to access protected API endpoints")
@@ -620,6 +620,14 @@ func (s *SmD) parseCmdLine() {
 			s.dbPortStr = val
 		}
 	}
+	envvar = "SMD_JWKS_URL"
+	if s.jwksURL == "" {
+		if val := os.Getenv(envvar); val != "" {
+			s.jwksURL = val
+			s.requireAuth = true
+		}
+	}
+
 	if s.dbPortStr == "" {
 		fmt.Printf("Missing DB port number")
 		flag.Usage()

--- a/cmd/smd/main.go
+++ b/cmd/smd/main.go
@@ -961,8 +961,9 @@ func main() {
 	router = s.NewRouter(publicRoutes, protectedRoutes)
 
 	s.LogAlways("GOMAXPROCS is: %v", runtime.GOMAXPROCS(0))
-	s.LogAlways("Listening for connections at: ", s.httpListen)
-	s.LogAlways("Registered SMD Routes: ", append(publicRoutes, protectedRoutes...))
+	s.LogAlways("Listening for connections at: %v", s.httpListen)
+	s.LogAlways("Registered SMD protected routes: %v", protectedRoutes)
+	s.LogAlways("Registered SMD public routes: %v", publicRoutes)
 	err = s.setupCerts(s.tlsCert, s.tlsKey)
 	if err == nil {
 		err = http.ListenAndServeTLS(s.httpListen, s.tlsCert, s.tlsKey, router)

--- a/cmd/smd/routers.go
+++ b/cmd/smd/routers.go
@@ -107,7 +107,6 @@ func (s *SmD) NewRouter(publicRoutes []Route, protectedRoutes []Route) *chi.Mux 
 				handler = handlers.CombinedLoggingHandler(os.Stdout, handler)
 				// handler = s.Logger(handler, route.Name)
 			}
-			s.LogAlways("route: %v\n", route.Pattern)
 			router.Method(
 				route.Method,
 				route.Pattern,
@@ -127,7 +126,6 @@ func (s *SmD) NewRouter(publicRoutes []Route, protectedRoutes []Route) *chi.Mux 
 				handler = handlers.CombinedLoggingHandler(os.Stdout, handler)
 				// handler = s.Logger(handler, route.Name)
 			}
-			s.LogAlways("route: %v\n", route.Pattern)
 			router.Method(
 				route.Method,
 				route.Pattern,

--- a/cmd/smd/routers.go
+++ b/cmd/smd/routers.go
@@ -76,6 +76,7 @@ func (s *SmD) NewRouter(publicRoutes []Route, protectedRoutes []Route) *chi.Mux 
 	router.Use(middleware.RealIP)
 	router.Use(middleware.Logger)
 	router.Use(middleware.Recoverer)
+	router.Use(middleware.StripSlashes)
 	router.NotFound(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.Logger(http.NotFoundHandler(), "NotFoundHandler")
 	}))

--- a/cmd/smd/routers.go
+++ b/cmd/smd/routers.go
@@ -47,7 +47,7 @@ type Route struct {
 
 type Routes []Route
 
-func (s *SmD) loadPublicKeyFromURL(url string) error {
+func (s *SmD) fetchPublicKeyFromURL(url string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	set, err := jwk.Fetch(ctx, url)
@@ -71,6 +71,7 @@ func (s *SmD) loadPublicKeyFromURL(url string) error {
 }
 
 func (s *SmD) NewRouter(publicRoutes []Route, protectedRoutes []Route) *chi.Mux {
+	// create router and use recommended middleware
 	router := chi.NewRouter()
 	router.Use(middleware.RequestID)
 	router.Use(middleware.RealIP)
@@ -114,7 +115,6 @@ func (s *SmD) NewRouter(publicRoutes []Route, protectedRoutes []Route) *chi.Mux 
 				(!strings.Contains(route.Name, "doReadyGet") &&
 					!strings.Contains(route.Name, "doLivenessGet")) {
 				handler = handlers.CombinedLoggingHandler(os.Stdout, handler)
-				// handler = s.Logger(handler, route.Name)
 			}
 			router.Method(
 				route.Method,
@@ -124,7 +124,6 @@ func (s *SmD) NewRouter(publicRoutes []Route, protectedRoutes []Route) *chi.Mux 
 		}
 
 	} else {
-		// router.NotFoundHandler = s.Logger(http.NotFoundHandler(), "NotFoundHandler")
 		routes := append(publicRoutes, protectedRoutes...)
 		for _, route := range routes {
 			var handler http.Handler
@@ -133,7 +132,6 @@ func (s *SmD) NewRouter(publicRoutes []Route, protectedRoutes []Route) *chi.Mux 
 				(!strings.Contains(route.Name, "doReadyGet") &&
 					!strings.Contains(route.Name, "doLivenessGet")) {
 				handler = handlers.CombinedLoggingHandler(os.Stdout, handler)
-				// handler = s.Logger(handler, route.Name)
 			}
 			router.Method(
 				route.Method,
@@ -156,17 +154,6 @@ func (s *SmD) getAllMethodsForRequest(req *http.Request) []string {
 		if s.router.Match(chi.NewRouteContext(), smdRoute.Method, smdRoute.Pattern) {
 			return []string{smdRoute.Method}
 		}
-
-		// route := s.router.Get(smdRoute.Name)
-		// if route != nil {
-		// 	var match mux.RouteMatch
-		// 	if route.Match(req, &match) || match.MatchErr == mux.ErrMethodMismatch {
-		// 		methods, err := route.GetMethods()
-		// 		if err == nil {
-		// 			allMethods = append(allMethods, methods...)
-		// 		}
-		// 	}
-		// }
 	}
 	return allMethods
 }


### PR DESCRIPTION
This PR includes a couple of small changes that have no impact on SMD's functionality aside from taking a URL string for fetching the JWKS keys from a remote host and adding a couple of standard recommended middleware for go-chi routers.