### PR TITLE
Removed auth flag and fixed jwks env var not working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ EXPOSE 27779
 # nobody 65534:65534
 USER 65534:65534
 
-CMD [ "/smd"]
+CMD [ "/smd" ]
 
 ENTRYPOINT [ "/sbin/tini", "--" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ EXPOSE 27779
 # nobody 65534:65534
 USER 65534:65534
 
-CMD [ "/smd" ]
+CMD [ "/smd"]
 
 ENTRYPOINT [ "/sbin/tini", "--" ]

--- a/cmd/smd/main.go
+++ b/cmd/smd/main.go
@@ -46,7 +46,7 @@ import (
 	"github.com/OpenCHAMI/smd/v2/internal/slsapi"
 	"github.com/OpenCHAMI/smd/v2/pkg/rf"
 	"github.com/OpenCHAMI/smd/v2/pkg/sm"
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/jwtauth/v5"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/sirupsen/logrus"

--- a/cmd/smd/main.go
+++ b/cmd/smd/main.go
@@ -110,7 +110,6 @@ type SmD struct {
 	smapCompEP       *SyncMap
 	genTestPayloads  string
 	disableDiscovery bool
-	requireAuth      bool
 
 	// v2 APIs
 	apiRootV2           string
@@ -559,10 +558,9 @@ func (s *SmD) parseCmdLine() {
 	flag.StringVar(&s.dbHost, "dbhost", "", "Database hostname")
 	flag.StringVar(&s.dbPortStr, "dbport", "", "Database port")
 	flag.StringVar(&s.dbOpts, "dbopts", "", "Database options string")
-	flag.StringVar(&s.jwksURL, "jwks-url", "https://127.0.0.1:9091/jwks.json", "Set the JWKS URL to fetch public key for validation")
+	flag.StringVar(&s.jwksURL, "jwks-url", "", "Set the JWKS URL to fetch public key for validation")
 	flag.BoolVar(&applyMigrations, "migrate", false, "Apply all database migrations before starting")
 	flag.BoolVar(&s.disableDiscovery, "disable-discovery", false, "Disable discovery-related subroutines")
-	flag.BoolVar(&s.requireAuth, "require-auth", false, "Require JWT authorization to access protected API endpoints")
 	help := flag.Bool("h", false, "Print help and exit")
 
 	flag.Parse()
@@ -624,7 +622,6 @@ func (s *SmD) parseCmdLine() {
 	if s.jwksURL == "" {
 		if val := os.Getenv(envvar); val != "" {
 			s.jwksURL = val
-			s.requireAuth = true
 		}
 	}
 
@@ -949,7 +946,7 @@ func main() {
 	}
 
 	// Initialize token authorization and load JWKS well-knowns from .well-known endpoint
-	if s.requireAuth {
+	if s.jwksURL != "" {
 		s.LogAlways("Fetching public key from server...")
 		for i := 0; i <= 5; i++ {
 			err = s.fetchPublicKeyFromURL(s.jwksURL)

--- a/cmd/smd/routers.go
+++ b/cmd/smd/routers.go
@@ -83,7 +83,7 @@ func (s *SmD) NewRouter(publicRoutes []Route, protectedRoutes []Route) *chi.Mux 
 	}))
 
 	router.Use(middleware.Timeout(60 * time.Second))
-	if s.requireAuth {
+	if s.jwksURL != "" {
 		router.Group(func(r chi.Router) {
 			r.Use(
 				jwtauth.Verifier(s.tokenAuth),

--- a/cmd/smd/routers.go
+++ b/cmd/smd/routers.go
@@ -30,8 +30,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/jwtauth/v5"
 	"github.com/gorilla/handlers"
 	"github.com/lestrrat-go/jwx/jwk"

--- a/cmd/smd/smd-api.go
+++ b/cmd/smd/smd-api.go
@@ -37,7 +37,7 @@ import (
 	"github.com/OpenCHAMI/smd/v2/internal/hmsds"
 	"github.com/OpenCHAMI/smd/v2/pkg/rf"
 	"github.com/OpenCHAMI/smd/v2/pkg/sm"
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v5"
 )
 
 type componentArrayIn struct {


### PR DESCRIPTION
This PR fixes the issue with the SMD_JWKS_URL environment variable not working due to the `jwksUrl` parameter being set by default. This also removes the `requireAuth` flag since authentication/authorization requires a JWKS public key.