### PR TITLE
Add logic to parse BMC manager data

### DIFF
--- a/cmd/smd/smd-api.go
+++ b/cmd/smd/smd-api.go
@@ -2671,9 +2671,10 @@ func (s *SmD) parseRedfishPostDataV2(w http.ResponseWriter, data []byte) error {
 		for _, eth := range manager.EthernetInterfaces {
 			// convert IP address from manager ethernet interface to IPAddressMapping
 			ips := []sm.IPAddressMapping{sm.IPAddressMapping{IPAddr: eth.IP}}
-			cei, err := sm.NewCompEthInterfaceV2(eth.Description, eth.MAC, manager.UUID, ips)
+			cei, err := sm.NewCompEthInterfaceV2(eth.Description, eth.MAC, component.ID, ips)
 			if err != nil {
 				sendJsonError(w, http.StatusBadRequest, err.Error())
+				continue
 			}
 			err = s.db.InsertCompEthInterface(cei)
 			if err != nil {
@@ -2685,6 +2686,7 @@ func (s *SmD) parseRedfishPostDataV2(w http.ResponseWriter, data []byte) error {
 					// an HMSError and not, e.g. an internal DB error code.
 					sendJsonDBError(w, "", "operation 'POST' failed during store.", err)
 				}
+				continue
 			}
 		}
 	}

--- a/cmd/smd/smd-api.go
+++ b/cmd/smd/smd-api.go
@@ -2692,7 +2692,7 @@ func (s *SmD) parseRedfishPostDataV2(w http.ResponseWriter, data []byte) error {
 	}
 
 	// iterate over all of the systems to create components and component endpoints
-	for _, system := range root.Systems {
+	for idx, system := range root.Systems {
 		var (
 			enabled   = strings.ToLower(system.PowerState) == "on"
 			component = base.Component{
@@ -2703,7 +2703,7 @@ func (s *SmD) parseRedfishPostDataV2(w http.ResponseWriter, data []byte) error {
 			}
 			componentEndpoint = sm.ComponentEndpoint{
 				ComponentDescription: rf.ComponentDescription{
-					ID:             root.ID,
+					ID:             root.ID + fmt.Sprintf("n%d", idx),
 					Type:           base.Node.String(),
 					RedfishType:    rf.ComputerSystemType, // TODO: need to get the RF type
 					RedfishSubtype: system.SystemType,     // TODO: need to get the RF subtype (SystemType)


### PR DESCRIPTION
This PR adds code to parse BMC manager information to create an additional component and its corresponding ethernet interfaces.