### PR TITLE
Add Version Information

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,6 +1,3 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
 name: Release with goreleaser
 
 on:
@@ -11,10 +8,7 @@ on:
 permissions: write-all # Necessary for the generate-build-provenance action with containers
 
 jobs:
-
   build:
-
-
     runs-on: ubuntu-latest
 
     steps:
@@ -35,6 +29,15 @@ jobs:
         with:
           fetch-tags: 1
           fetch-depth: 1
+          
+      # Set environment variables required by GoReleaser
+      - name: Set build environment variables
+        run: |
+          echo "GIT_STATE=$(if git diff-index --quiet HEAD --; then echo 'clean'; else echo 'dirty'; fi)" >> $GITHUB_ENV
+          echo "BUILD_HOST=$(hostname)" >> $GITHUB_ENV
+          echo "GO_VERSION=$(go version | awk '{print $3}')" >> $GITHUB_ENV
+          echo "BUILD_USER=$(whoami)" >> $GITHUB_ENV
+
       - name: Release with goreleaser
         uses: goreleaser/goreleaser-action@v5
         env:
@@ -43,6 +46,7 @@ jobs:
           version: latest
           args: release --clean
         id: goreleaser
+
       - name: Process goreleaser output
         id: process_goreleaser_output
         run: |
@@ -53,18 +57,22 @@ jobs:
           echo "fs.writeFileSync('digest.txt', firstNonNullDigest);" >> process.js
           node process.js
           echo "digest=$(cat digest.txt)" >> $GITHUB_OUTPUT
+          
       - name: Attest smd binary
         uses: github-early-access/generate-build-provenance@main
         with:
           subject-path: dist/smd
+          
       - name: Attest smd-init binary
         uses: github-early-access/generate-build-provenance@main
         with:
           subject-path: dist/smd-init
+          
       - name: Attest smd-loader binary
         uses: github-early-access/generate-build-provenance@main
         with:
           subject-path: dist/smd-loader
+          
       - name: generate build provenance
         uses: github-early-access/generate-build-provenance@main
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,16 @@ builds:
   - id: smd
     main: ./cmd/smd/
     binary: smd
+    ldflags:
+      - "-X main.GitCommit={{.Commit}} \
+         -X main.BuildTime={{.Timestamp}} \
+         -X main.Version={{.Version}} \
+         -X main.GitBranch={{.Branch}} \
+         -X main.GitTag={{.Tag}} \
+         -X main.GitState={{if .IsDirty}}dirty{{else}}clean{{end}} \
+         -X main.BuildHost={{.Env.HOSTNAME}} \
+         -X main.GoVersion={{.Env.GOVERSION}} \
+         -X main.BuildUser={{.Env.USER}}"
     goos:
       - linux
     goarch:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,16 +11,20 @@ builds:
   - id: smd
     main: ./cmd/smd/
     binary: smd
+    # export GIT_STATE=$(if git diff-index --quiet HEAD --; then echo 'clean'; else echo 'dirty'; fi)
+    # export BUILD_HOST=$(hostname)
+    # export GO_VERSION=$(go version | awk '{print $3}')
+    # export BUILD_USER=$(whoami)
     ldflags:
       - "-X main.GitCommit={{.Commit}} \
          -X main.BuildTime={{.Timestamp}} \
          -X main.Version={{.Version}} \
          -X main.GitBranch={{.Branch}} \
          -X main.GitTag={{.Tag}} \
-         -X main.GitState=$(if git diff-index --quiet HEAD --; then echo 'clean'; else echo 'dirty'; fi) \
-         -X main.BuildHost=$(hostname) \
-         -X main.GoVersion=$(go version | awk '{print $3}') \
-         -X main.BuildUser=$(whoami)"
+         -X main.GitState=${GIT_STATE:-unknown} \
+         -X main.BuildHost=${BUILD_HOST:-unknown} \
+         -X main.GoVersion=${GO_VERSION:-unknown} \
+         -X main.BuildUser=${BUILD_USER:-unknown}"
     goos:
       - linux
     goarch:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+version: 2
 
 project_name: smd
 before:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,15 +21,16 @@ builds:
          -X main.Version={{.Version}} \
          -X main.GitBranch={{.Branch}} \
          -X main.GitTag={{.Tag}} \
-         -X main.GitState=${GIT_STATE:-unknown} \
-         -X main.BuildHost=${BUILD_HOST:-unknown} \
-         -X main.GoVersion=${GO_VERSION:-unknown} \
-         -X main.BuildUser=${BUILD_USER:-unknown}"
+         -X main.GitState={{ .Env.GIT_STATE }} \
+         -X main.BuildHost={{ .Env.BUILD_HOST }} \
+         -X main.GoVersion={{ .Env.GO_VERSION }} \
+         -X main.BuildUser={{ .Env.BUILD_USER }}"
     goos:
       - linux
+      - darwin
     goarch:
       - amd64
-    no_unique_dist_dir: true
+      - arm64
     tags:
       - musl
       - dynamic
@@ -39,9 +40,10 @@ builds:
     binary: smd-init
     goos:
       - linux
+      - darwin
     goarch:
       - amd64
-    no_unique_dist_dir: true
+      - arm64
     tags:
       - musl
       - dynamic
@@ -50,9 +52,10 @@ builds:
     binary: smd-loader
     goos:
       - linux
+      - darwin
     goarch:
       - amd64
-    no_unique_dist_dir: true
+      - arm64
     tags:
       - musl
       - dynamic

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,10 +17,10 @@ builds:
          -X main.Version={{.Version}} \
          -X main.GitBranch={{.Branch}} \
          -X main.GitTag={{.Tag}} \
-         -X main.GitState={{if .IsDirty}}dirty{{else}}clean{{end}} \
-         -X main.BuildHost={{.Env.HOSTNAME}} \
-         -X main.GoVersion={{.Env.GOVERSION}} \
-         -X main.BuildUser={{.Env.USER}}"
+         -X main.GitState=$(if git diff-index --quiet HEAD --; then echo 'clean'; else echo 'dirty'; fi) \
+         -X main.BuildHost=$(hostname) \
+         -X main.GoVersion=$(go version | awk '{print $3}') \
+         -X main.BuildUser=$(whoami)"
     goos:
       - linux
     goarch:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,42 @@ While the OpenCHAMI smd daemon is fundamentally the same as the original from HP
 
 It still provides inventory management services for HPC systems based on BMC discovery and enumeration.
 
+## Build/Install with goreleaser
+
+This project uses [GoReleaser](https://goreleaser.com/) to automate releases and include additional build metadata such as commit info, build time, and versioning. Below is a guide on how to set up and build the project locally using GoReleaser.
+
+### Environment Variables
+
+To include detailed build metadata, ensure the following environment variables are set:
+
+* __GIT_STATE__: Indicates whether there are uncommitted changes in the working directory. Set to clean if the repository is clean, or dirty if there are uncommitted changes.
+* __BUILD_HOST__: The hostname of the machine where the build is being performed. 
+* __GO_VERSION__: The version of Go used for the build. GoReleaser uses this to ensure consistent Go versioning information.
+* __BUILD_USER__: The username of the person or system performing the build.
+
+Set all the environment variables with:
+```bash
+export GIT_STATE=$(if git diff-index --quiet HEAD --; then echo 'clean'; else echo 'dirty'; fi)
+export BUILD_HOST=$(hostname)
+export GO_VERSION=$(go version | awk '{print $3}')
+export BUILD_USER=$(whoami)
+```
+
+### Building Locally with GoReleaser
+
+Once the environment variables are set, you can build the project locally using GoReleaser in snapshot mode (to avoid publishing).
+
+
+Follow the installation instructions from [GoReleaser’s documentation](https://goreleaser.com/install/).
+
+1. Run GoReleaser in snapshot mode with the --snapshot and --skip-publish flags to create a local build without attempting to release it:
+  ```bash
+  goreleaser release --snapshot --skip-publish --clean
+  ```
+2.	Check the dist/ directory for the built binaries, which will include the metadata from the environment variables. You can inspect the binary output to confirm that the metadata was correctly embedded.
+
+
+
 The rest of this README is unchanged from the HPE version.
 __________________________________________________________________
 

--- a/cmd/smd/main.go
+++ b/cmd/smd/main.go
@@ -732,6 +732,8 @@ func (s *SmD) setDSN() {
 }
 
 func main() {
+	PrintVersionInfo()
+
 	var s SmD
 	var err error
 

--- a/cmd/smd/main.go
+++ b/cmd/smd/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/Cray-HPE/hms-certs/pkg/hms_certs"
 	compcreds "github.com/Cray-HPE/hms-compcredentials"
 	sstorage "github.com/Cray-HPE/hms-securestorage"
+	jwtauth "github.com/OpenCHAMI/jwtauth/v5"
 	"github.com/OpenCHAMI/smd/v2/internal/hbtdapi"
 	"github.com/OpenCHAMI/smd/v2/internal/hmsds"
 	"github.com/OpenCHAMI/smd/v2/internal/pgmigrate"
@@ -47,15 +48,8 @@ import (
 	"github.com/OpenCHAMI/smd/v2/pkg/rf"
 	"github.com/OpenCHAMI/smd/v2/pkg/sm"
 	"github.com/go-chi/chi/v5"
-	jwtauth "github.com/OpenCHAMI/jwtauth/v5"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/sirupsen/logrus"
-)
-
-var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
 )
 
 const (
@@ -779,8 +773,8 @@ func main() {
 			serviceName)
 	}
 
-	s.LogAlways("Starting... " + serviceName + " " + version + " " + commit + "\n")
-
+	s.LogAlways("Starting... " + serviceName + " " + Version + " " + GitCommit + "\n")
+	s.LogAlways(VersionInfo())
 	// Route logs from Redfish interrogration to main smd log.
 	rf.SetLogger(s.lg)
 	// Route logs for sm module to main smd log

--- a/cmd/smd/version.go
+++ b/cmd/smd/version.go
@@ -1,0 +1,58 @@
+package main
+
+import "fmt"
+
+// GitCommit stores the latest Git commit hash.
+// Set via -ldflags "-X main.GitCommit=$(git rev-parse HEAD)"
+var GitCommit string
+
+// BuildTime stores the build timestamp in UTC.
+// Set via -ldflags "-X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+var BuildTime string
+
+// Version indicates the version of the binary, such as a release number or semantic version.
+// Set via -ldflags "-X main.Version=v1.0.0"
+var Version string
+
+// GitBranch holds the name of the Git branch from which the build was created.
+// Set via -ldflags "-X main.GitBranch=$(git rev-parse --abbrev-ref HEAD)"
+var GitBranch string
+
+// GitTag represents the most recent Git tag at build time, if any.
+// Set via -ldflags "-X main.GitTag=$(git describe --tags --abbrev=0)"
+var GitTag string
+
+// GitState indicates whether the working directory was "clean" or "dirty" (i.e., with uncommitted changes).
+// Set via -ldflags "-X main.GitState=$(if git diff-index --quiet HEAD --; then echo 'clean'; else echo 'dirty'; fi)"
+var GitState string
+
+// BuildHost stores the hostname of the machine where the binary was built.
+// Set via -ldflags "-X main.BuildHost=$(hostname)"
+var BuildHost string
+
+// GoVersion captures the Go version used to build the binary.
+// Typically, this can be obtained automatically with runtime.Version(), but you can set it manually.
+// Set via -ldflags "-X main.GoVersion=$(go version | awk '{print $3}')"
+var GoVersion string
+
+// BuildUser is the username of the person or system that initiated the build process.
+// Set via -ldflags "-X main.BuildUser=$(whoami)"
+var BuildUser string
+
+// PrintVersionInfo outputs all versioning information for troubleshooting or version checks.
+func PrintVersionInfo() {
+	fmt.Printf("Version: %s\n", Version)
+	fmt.Printf("Git Commit: %s\n", GitCommit)
+	fmt.Printf("Build Time: %s\n", BuildTime)
+	fmt.Printf("Git Branch: %s\n", GitBranch)
+	fmt.Printf("Git Tag: %s\n", GitTag)
+	fmt.Printf("Git State: %s\n", GitState)
+	fmt.Printf("Build Host: %s\n", BuildHost)
+	fmt.Printf("Go Version: %s\n", GoVersion)
+	fmt.Printf("Build User: %s\n", BuildUser)
+}
+
+func VersionInfo() string {
+	return fmt.Sprintf("Version: %s, Git Commit: %s, Build Time: %s, Git Branch: %s, Git Tag: %s, Git State: %s, Build Host: %s, Go Version: %s, Build User: %s",
+		Version, GitCommit, BuildTime, GitBranch, GitTag, GitState, BuildHost, GoVersion, BuildUser)
+}

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,6 @@ github.com/openchami/chi-middleware/auth v0.0.0-20240812224658-b16b83c70700 h1:X
 github.com/openchami/chi-middleware/auth v0.0.0-20240812224658-b16b83c70700/go.mod h1:kswb9kU5cZAFRAvf1dAUJRWbQyjDEb0qkxW4ncDdEXg=
 github.com/openchami/chi-middleware/log v0.0.0-20240812224658-b16b83c70700 h1:Gzt5f6RK39CHvY3SJudzBb/RK4tVh/S3CpJ0eQlbNdg=
 github.com/openchami/chi-middleware/log v0.0.0-20240812224658-b16b83c70700/go.mod h1:UuXvr2loD4MtvZeKr57W0WpBs+gm0KM1kdtcXrE8M6s=
-github.com/openchami/schemas v0.0.0-20240819151820-7a7e0fd6c9d7 h1:5rh4vZFp+FuSt3YeyoK1HR2gX83xmBtH9nNavmbKptY=
-github.com/openchami/schemas v0.0.0-20240819151820-7a7e0fd6c9d7/go.mod h1:3dridLqXvAdO0ypPXuxnXRgaK2h/dItVKGseCgFQ13k=
 github.com/openchami/schemas v0.0.0-20240822140637-d8f34a22a2d4 h1:XuGfSgAuuR8/TIWRDMSGF6VKSr/OMYD7kGtJSk9oemM=
 github.com/openchami/schemas v0.0.0-20240822140637-d8f34a22a2d4/go.mod h1:3dridLqXvAdO0ypPXuxnXRgaK2h/dItVKGseCgFQ13k=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=


### PR DESCRIPTION
It has been bugging me for a while that our builds don't embed the build environment into the compiled binaries.  Go supports this with ldflags and goreleaser supports using environment variables with ldflags.

This PR adds a version.go file and two functions useful for printing the version information along with automation to build using goreleaser and the associated github action.  The README is updated as well so that folks building locally can learn how to properly set the environment variables.

This PR also cleans up a few things in the goreleaser file to allow building for all architectures.  The docker container remains amd64 only.

Output on Linux
```bash
❯ dist/smd_linux_amd64_v1/smd
Version: 2.16.2-next
Git Commit: be5275869d817290ae98e6907ff82222193f224b
Build Time: 1729880661
Git Branch: alexlovelltroy/add-version-info
Git Tag: v2.16.1
Git State: clean
Build Host: debian-11
Go Version: go1.23.2
Build User: alt
```

Output using docker:
```bash
❯ docker run ghcr.io/openchami/smd:latest
Version: 2.16.2-next
Git Commit: be5275869d817290ae98e6907ff82222193f224b
Build Time: 1729880661
Git Branch: alexlovelltroy/add-version-info
Git Tag: v2.16.1
Git State: clean
Build Host: debian-11
Go Version: go1.23.2
Build User: alt
```