### PR TITLE
Update `doRedfishEndpointPut` to create/update entry instead of just update

### DIFF
--- a/cmd/smd/smd-api.go
+++ b/cmd/smd/smd-api.go
@@ -2311,14 +2311,14 @@ func (s *SmD) doRedfishEndpointPut(w http.ResponseWriter, r *http.Request) {
 	)
 	if schemaVersion <= 0 {
 		// parse data and populate component endpoints before inserting into db
-		err = s.parseRedfishPostData(w, eps, body)
+		err = s.parseRedfishEndpointData(w, eps, body)
 		if err != nil {
 			sendJsonError(w, http.StatusInternalServerError,
 				fmt.Sprintf("failed parsing post data: %w", err))
 		}
 	} else {
 		// parse data using the new inventory data format (will conform to schema)
-		err = s.parseRedfishPostDataV2(w, body)
+		err = s.parseRedfishEndpointDataV2(w, body)
 		if err != nil {
 			sendJsonError(w, http.StatusInternalServerError,
 				fmt.Sprintf("failed parsing post data (V2): %w", err))
@@ -2562,14 +2562,14 @@ func (s *SmD) doRedfishEndpointsPost(w http.ResponseWriter, r *http.Request) {
 	schemaVersion := s.getSchemaVersion(w, body)
 	if schemaVersion <= 0 {
 		// parse data and populate component endpoints before inserting into db
-		err = s.parseRedfishPostData(w, eps, body)
+		err = s.parseRedfishEndpointData(w, eps, body)
 		if err != nil {
 			sendJsonError(w, http.StatusInternalServerError,
 				fmt.Sprintf("failed parsing post data: %w", err))
 		}
 	} else {
 		// parse data using the new inventory data format (will conform to schema)
-		err = s.parseRedfishPostDataV2(w, body)
+		err = s.parseRedfishEndpointDataV2(w, body)
 		if err != nil {
 			sendJsonError(w, http.StatusInternalServerError,
 				fmt.Sprintf("failed parsing post data (V2): %w", err))
@@ -2583,7 +2583,7 @@ func (s *SmD) doRedfishEndpointsPost(w http.ResponseWriter, r *http.Request) {
 
 // Parse the incoming JSON data, extracts specific keys, and writes the data
 // to the database
-func (s *SmD) parseRedfishPostData(w http.ResponseWriter, eps *sm.RedfishEndpointArray, data []byte) error {
+func (s *SmD) parseRedfishEndpointData(w http.ResponseWriter, eps *sm.RedfishEndpointArray, data []byte) error {
 	s.lg.Printf("parsing request data using default parsing method...")
 	var obj map[string]any
 	err := json.Unmarshal(data, &obj)
@@ -2672,7 +2672,7 @@ func (s *SmD) parseRedfishPostData(w http.ResponseWriter, eps *sm.RedfishEndpoin
 	return nil
 }
 
-func (s *SmD) parseRedfishPostDataV2(w http.ResponseWriter, data []byte) error {
+func (s *SmD) parseRedfishEndpointDataV2(w http.ResponseWriter, data []byte) error {
 	s.lg.Printf("parsing request data using V2 parsing method...")
 
 	// NOTE: temporary definition for manager

--- a/cmd/smd/smd-api.go
+++ b/cmd/smd/smd-api.go
@@ -2275,7 +2275,6 @@ func (s *SmD) doRedfishEndpointPut(w http.ResponseWriter, r *http.Request) {
 		// No error, but no update: Resource was not found.
 		// s.lg.Printf("doRedfishEndpointPut: No such entry %s", rep.ID)
 		// sendJsonError(w, http.StatusNotFound, "No such entry: "+rep.ID)
-		return
 	}
 
 	// Store credentials that are given in vault

--- a/cmd/smd/smd-api.go
+++ b/cmd/smd/smd-api.go
@@ -2763,13 +2763,14 @@ func (s *SmD) parseRedfishEndpointDataV2(w http.ResponseWriter, data []byte, for
 				} else {
 					// Send this message as 500 or 400 plus error message if it is
 					// an HMSError and not, e.g. an internal DB error code.
-					sendJsonDBError(w, "", "operation 'POST' failed during store.", err)
+					sendJsonDBError(w, "", "operation failed during store.", err)
 				}
 				if forceUpdate {
-					// try deleting and reinserting the CompEthInterface
+					// try deleting and reinserting the CompEthInterface since there is not an upsert/update function
 					rowAffected, err := s.db.DeleteCompEthInterfaceByID(cei.ID)
 					if err != nil {
-
+						sendJsonDBError(w, "", "operation failed trying to delete component ethernet interface.", err)
+						continue
 					}
 					if rowAffected {
 						err = s.db.InsertCompEthInterface(cei)
@@ -2779,7 +2780,7 @@ func (s *SmD) parseRedfishEndpointDataV2(w http.ResponseWriter, data []byte, for
 						} else {
 							// Send this message as 500 or 400 plus error message if it is
 							// an HMSError and not, e.g. an internal DB error code.
-							sendJsonDBError(w, "", "operation 'POST' failed during store.", err)
+							sendJsonDBError(w, "", "operation  failed during store.", err)
 						}
 					}
 				}

--- a/cmd/smd/smd-api.go
+++ b/cmd/smd/smd-api.go
@@ -2739,7 +2739,7 @@ func (s *SmD) parseRedfishEndpointDataV2(w http.ResponseWriter, data []byte, for
 				// upsert here to keep allow returning error for duplicates when not forcing updates
 				_, err := s.db.UpsertComponents([]*base.Component{&component}, false)
 				if err != nil {
-					return fmt.Errorf("failed to update component: %w", rowsAffected, err)
+					return fmt.Errorf("failed to update component: %w", err)
 				}
 			} else {
 				return fmt.Errorf("failed to insert %d component(s): %w", rowsAffected, err)
@@ -2844,7 +2844,7 @@ func (s *SmD) parseRedfishEndpointDataV2(w http.ResponseWriter, data []byte, for
 				// upsert here to keep allow returning error for duplicates when not forcing updates
 				_, err := s.db.UpsertComponents([]*base.Component{&component}, false)
 				if err != nil {
-					return fmt.Errorf("failed to update component: %w", rowsAffected, err)
+					return fmt.Errorf("failed to update component: %w", err)
 				}
 				return fmt.Errorf("failed to insert %d component(s): %w", rowsAffected, err)
 			}

--- a/cmd/smd/smd-api.go
+++ b/cmd/smd/smd-api.go
@@ -2219,7 +2219,6 @@ func (s *SmD) doRedfishEndpointPut(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// TODO: Change behavior to create a new RedfishEndpoint entry
 	retEP, affectedIDs, err := s.db.UpdateRFEndpointNoDiscInfo(ep)
 	if err != nil {
 		s.lg.Printf("failed: %s %s, Err: %s", r.RemoteAddr, string(body), err)
@@ -2247,34 +2246,29 @@ func (s *SmD) doRedfishEndpointPut(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// check for the data format sent via the schema version
-		var (
-			schemaVersion = s.getSchemaVersion(w, body)
-			eps           = &sm.RedfishEndpointArray{
-				RedfishEndpoints: []*sm.RedfishEndpoint{ep},
-			}
-		)
-		if schemaVersion <= 0 {
-			// parse data and populate component endpoints before inserting into db
-			err = s.parseRedfishEndpointData(w, eps, body)
-			if err != nil {
-				sendJsonError(w, http.StatusInternalServerError,
-					fmt.Sprintf("failed parsing post data: %w", err))
-			}
-		} else {
-			// parse data using the new inventory data format (will conform to schema)
-			err = s.parseRedfishEndpointDataV2(w, body, true)
-			if err != nil {
-				sendJsonError(w, http.StatusInternalServerError,
-					fmt.Sprintf("failed parsing post data (V2): %w", err))
-			}
-		}
+	}
 
-		// TODO: This is too be removed since we don't want this behavior.
-		//
-		// No error, but no update: Resource was not found.
-		// s.lg.Printf("doRedfishEndpointPut: No such entry %s", rep.ID)
-		// sendJsonError(w, http.StatusNotFound, "No such entry: "+rep.ID)
+	// parse incoming data to add components, component endpoints, and ethernet interfaces
+	var (
+		schemaVersion = s.getSchemaVersion(w, body)
+		eps           = &sm.RedfishEndpointArray{
+			RedfishEndpoints: []*sm.RedfishEndpoint{ep},
+		}
+	)
+	if schemaVersion <= 0 {
+		// parse data and populate component endpoints before inserting into db
+		err = s.parseRedfishEndpointData(w, eps, body)
+		if err != nil {
+			sendJsonError(w, http.StatusInternalServerError,
+				fmt.Sprintf("failed parsing post data: %w", err))
+		}
+	} else {
+		// parse data using the new inventory data format (will conform to schema)
+		err = s.parseRedfishEndpointDataV2(w, body, true)
+		if err != nil {
+			sendJsonError(w, http.StatusInternalServerError,
+				fmt.Sprintf("failed parsing post data (V2): %w", err))
+		}
 	}
 
 	// Store credentials that are given in vault
@@ -2758,31 +2752,38 @@ func (s *SmD) parseRedfishEndpointDataV2(w http.ResponseWriter, data []byte, for
 			err = s.db.InsertCompEthInterface(cei)
 			if err != nil {
 				if err == hmsds.ErrHMSDSDuplicateKey {
-					sendJsonError(w, http.StatusConflict, "operation would conflict "+
-						"with an existing component ethernet interface that has the same MAC address.")
+					if forceUpdate {
+						// Duplicate key detected, but foreceUpdate enabled, so we delete and readd.
+
+						// try deleting and reinserting the CompEthInterface since there is not an upsert/update function
+						rowAffected, err := s.db.DeleteCompEthInterfaceByID(cei.ID)
+						if err != nil {
+							sendJsonDBError(w, "", "operation failed trying to delete component ethernet interface.", err)
+							continue
+						}
+						if rowAffected {
+							err = s.db.InsertCompEthInterface(cei)
+							if err != nil {
+								if err == hmsds.ErrHMSDSDuplicateKey {
+									sendJsonError(w, http.StatusConflict, "operation would conflict "+
+										"with an existing component ethernet interface that has the same MAC address.")
+								} else {
+									// Send this message as 500 or 400 plus error message if it is
+									// an HMSError and not, e.g. an internal DB error code.
+									sendJsonDBError(w, "", "operation  failed during store.", err)
+								}
+							}
+						}
+					} else {
+						// forceUpdate was not enabled when duplicate key was found, so we err.
+						sendJsonError(w, http.StatusConflict, "operation would conflict "+
+							"with an existing component ethernet interface that has the same MAC address.")
+					}
 				} else {
+					// Some other error occurred that we want to let the user know about.
 					// Send this message as 500 or 400 plus error message if it is
 					// an HMSError and not, e.g. an internal DB error code.
 					sendJsonDBError(w, "", "operation failed during store.", err)
-				}
-				if forceUpdate {
-					// try deleting and reinserting the CompEthInterface since there is not an upsert/update function
-					rowAffected, err := s.db.DeleteCompEthInterfaceByID(cei.ID)
-					if err != nil {
-						sendJsonDBError(w, "", "operation failed trying to delete component ethernet interface.", err)
-						continue
-					}
-					if rowAffected {
-						err = s.db.InsertCompEthInterface(cei)
-						if err == hmsds.ErrHMSDSDuplicateKey {
-							sendJsonError(w, http.StatusConflict, "operation would conflict "+
-								"with an existing component ethernet interface that has the same MAC address.")
-						} else {
-							// Send this message as 500 or 400 plus error message if it is
-							// an HMSError and not, e.g. an internal DB error code.
-							sendJsonDBError(w, "", "operation  failed during store.", err)
-						}
-					}
 				}
 				continue
 			}


### PR DESCRIPTION
Addresses #44 by changing the behavior of `doRedfishEndpointPut` to create a new `RedfishEndpoint` if it does not exist for the `/Inventory/RedfishEndpoints/{xname}` endpoint. It should also parse data with `Systems` and `Managers` properties similar to the `doRedfishEndpointPost` function and create `RedfishEndpoint`, `Components`, and `ComponentEndpoints`. 

To test, try sending data to the endpoint mentioned above (may need verification):

```bash
curl -X PUT  $SMD_BASE_URL/Inventory/RedfishEndpoints/x1000c1s7b0 -d @data.json  --cacert $CACERT_PATH -H "Authorization: Bearer $ACCESS_TOKEN"
```
Where `data.json` is something like the following:

```json
{
  "ID": "x1000c1s7b0",
  "Type": "NodeBMC",
  "Name": "cg01",
  "MACAddr": "b4:2e:99:a6:63:cf",
  "IPAddress": "172.16.0.101",
  "SchemaVersion": 1,
  "Systems": [
    {
      "uri": "https://cable-guys.si.usrc/redfish/v1/Systems/x1000c1s7b0n0",
      "name": "cg01",
      "ethernet_interfaces": [
        {
          "mac": "b4:2e:99:a6:06:47",
          "ip": "172.16.0.1",
          "name": "x1000c1s7b0n0",
          "description": "Interface 0 for cg01"
        }
      ]
    }
  ],
  "Managers": [
    {
      "uri": "https://cable-guys.si.usrc/redfish/v1/Managers/x1000c1s7b0",
      "name": "x1000c1s7b0",
      "ethernet_interfaces": [
        {
          "mac": "b4:2e:99:a6:63:cf",
          "ip": "172.16.0.101",
          "name": "x1000c1s7b0",
          "description": "Interface for BMC x1000c1s7b0"
        }
      ],
      "type": "NodeBMC"
    }
  ]
}
```

Some other things to consider before merging:

- Should there also be a check that limits the parsing to a single entry in the data? 
- Should we use the `xname` provided in the URL or in the request body (it's usually specified in the body like seen above)?