### PR TITLE
Add PUT method to /group/{id}/members

### DIFF
--- a/api/swagger_v2.yaml
+++ b/api/swagger_v2.yaml
@@ -5125,6 +5125,57 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Problem7807'
+    put:
+      tags:
+        - Group
+      summary: Set member of existing group (via PUT)
+      description: >-
+        Set the member list for group {group_label} to the list of
+        component xname IDs provided in the payload. If any members
+        in the payload already exist in the group, they remain in
+        the group. If any members in the payload do not already
+        exist in the group, they are added to the group. Any xnames
+        that exist in the group that are not in the payload are
+        removed from the group.
+      operationId: doGroupMembersPut
+      parameters:
+        - name: group_label
+          in: path
+          type: string
+          required: true
+          description: >-
+            Specifies an existing group {group_label} whose member list to set.
+        - name: payload
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/MemberList'
+      responses:
+        "201":
+          description: >-
+            Success, returns array containing the created member URIs.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/ResourceURI.1.0.0'
+          examples:
+            application/json:
+              - uri: /hsm/v2/groups/compute/members/x0c0s1b0n0
+              - uri: /hsm/v2/groups/compute/members/x0c0s1b0n1
+              - uri: /hsm/v2/groups/compute/members/x0c0s3b0n0
+              - uri: /hsm/v2/groups/compute/members/x0c0s3b0n1
+        "400":
+          description: Bad Request - e.g. malformed string
+          schema:
+            $ref: '#/definitions/Problem7807'
+        "404":
+          description: Does not exist - No such group {group_label}
+          schema:
+            $ref: '#/definitions/Problem7807'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Problem7807'
   /groups/{group_label}/members/{xname_id}:
     delete:
       tags:
@@ -10514,6 +10565,30 @@ definitions:
           $ref: '#/definitions/XNameRW.1.0.0'   # String with XName format
     type: object
     example:
+      ids:
+        - x1c0s1b0n0
+        - x1c0s1b0n1
+        - x2c0s3b0n0
+        - x2c0s3b0n1
+  MemberList:
+    description: >-
+      A MemberList is a mapping of group name to its members.
+    properties:
+      group:
+        description: >-
+          The group's ID
+        type: string
+        example:
+          group: compute
+      ids:
+        description: >-
+          Set of Component XName IDs that represent the membership of the
+          group or partition.
+        type: array
+        items:
+          $ref: '#/definitions/XNameRW.1.0.0'   # String with XName format
+    example:
+      group: compute
       ids:
         - x1c0s1b0n0
         - x1c0s1b0n1

--- a/api/swagger_v2.yaml
+++ b/api/swagger_v2.yaml
@@ -4157,7 +4157,7 @@ paths:
             $ref: '#/definitions/ResourceURI.1.0.0'
           examples:
             application/json:
-              uri: /hsm/v2/Inventory/a4bf012b7311
+              URI: /hsm/v2/Inventory/a4bf012b7311
         "400":
           description: Bad Request
           schema:
@@ -4877,7 +4877,7 @@ paths:
               $ref: '#/definitions/ResourceURI.1.0.0'
           examples:
             application/json:
-              - uri: /hsm/v2/groups/mygrouplabel
+              - URI: /hsm/v2/groups/mygrouplabel
         "400":
           description: Bad Request
           schema:
@@ -5108,7 +5108,7 @@ paths:
               $ref: '#/definitions/ResourceURI.1.0.0'
           examples:
             application/json:
-              - uri: /hsm/v2/groups/mygrouplabel/members/x0c0s1b0n0
+              - URI: /hsm/v2/groups/mygrouplabel/members/x0c0s1b0n0
         "400":
           description: Bad Request - e.g. malformed string
           schema:
@@ -5160,10 +5160,10 @@ paths:
               $ref: '#/definitions/ResourceURI.1.0.0'
           examples:
             application/json:
-              - uri: /hsm/v2/groups/compute/members/x0c0s1b0n0
-              - uri: /hsm/v2/groups/compute/members/x0c0s1b0n1
-              - uri: /hsm/v2/groups/compute/members/x0c0s3b0n0
-              - uri: /hsm/v2/groups/compute/members/x0c0s3b0n1
+              - URI: /hsm/v2/groups/compute/members/x0c0s1b0n0
+              - URI: /hsm/v2/groups/compute/members/x0c0s1b0n1
+              - URI: /hsm/v2/groups/compute/members/x0c0s3b0n0
+              - URI: /hsm/v2/groups/compute/members/x0c0s3b0n1
         "400":
           description: Bad Request - e.g. malformed string
           schema:
@@ -5288,7 +5288,7 @@ paths:
               $ref: '#/definitions/ResourceURI.1.0.0'
           examples:
             application/json:
-              - uri: /hsm/v2/partitions/p1
+              - URI: /hsm/v2/partitions/p1
         "400":
           description: Bad Request
           schema:
@@ -5507,7 +5507,7 @@ paths:
               $ref: '#/definitions/ResourceURI.1.0.0'
           examples:
             application/json:
-              - uri: /hsm/v2/partitions/p1/members/x0c0s1b0n0
+              - URI: /hsm/v2/partitions/p1/members/x0c0s1b0n0
         "400":
           description: Bad Request - Bad partition_name or malformed string?
           schema:

--- a/cmd/smd/routers.go
+++ b/cmd/smd/routers.go
@@ -790,6 +790,12 @@ func (s *SmD) generateProtectedRoutes() Routes {
 			s.doGroupMembersPost,
 		},
 		Route{
+			"doGroupMembersPutV2",
+			strings.ToUpper("Put"),
+			s.groupsBaseV2 + "/{group_label}/members",
+			s.doGroupMembersPut,
+		},
+		Route{
 			"doGroupMemberDeleteV2",
 			strings.ToUpper("Delete"),
 			s.groupsBaseV2 + "/{group_label}/members/{xname_id}",

--- a/internal/hmsds/hmsds-api.go
+++ b/internal/hmsds/hmsds-api.go
@@ -803,6 +803,14 @@ type HMSDB interface {
 	// group was present to remove.
 	DeleteGroupMember(label, id string) (bool, error)
 
+	// Set group member list for label to ids. If xnames in ids are in the
+	// group, they remain in the group. If xnames in ids are not in the
+	// group, they are added to the group. If xnames are not in ids but are
+	// in the group, they are removed from the group.
+	//
+	// Returns the ids of the members set in the group's member list.
+	SetGroupMembers(label string, ids []string) ([]string, error)
+
 	//                        Partitions
 
 	// Create a partition.  Returns new name (should match one in struct,
@@ -1538,6 +1546,10 @@ type HMSDBTx interface {
 	// Given an internal group_id uuid, delete the given id, if it exists.
 	// if it does not, result will be false, nil vs. true,nil on deletion.
 	DeleteMemberTx(uuid, id string) (bool, error)
+
+	// Given an internal group_id uuid, if it exists, delete all of its
+	// member ids. Result is number of member ids deleted.
+	DeleteMembersAllTx(guuid string) (int64, error)
 
 	//                                                                    //
 	//                    Component Lock Management                       //

--- a/pkg/sm/groups.go
+++ b/pkg/sm/groups.go
@@ -83,6 +83,12 @@ type MemberAddBody struct {
 	ID string `json:"id"` // xname
 }
 
+// For PUT to members endpoint to set group member list
+type MemberPutBody struct {
+	Group string   `json:"group"`
+	IDs   []string `json:"ids"`
+}
+
 // Check ids array for xname fitneess.  If no error is returned,
 // the ids are valid.
 func (ms *Members) Verify() error {


### PR DESCRIPTION
Add the ability to send the `/hsm/v2/group/{id}/members` endpoint a PUT request. This is very useful for idempotent member list setting. The behavior of this request "sets" the member list of group `{id}`. In other words:

- If an xname in the payload exists in group `{id}`, it remains in the group.
- If an xname in the payload does _not_ exist in group `{id}`, it is added to the group.
- If an exname id _not_ in the payload but is in group `{id}`, it is removed from the group.

The payload for a PUT request is, for example, to set the members for group "compute":

```json
{
  "group": "compute",
  "ids": [
    "x1c0s1b0n0",
    "x1c0s1b0n1",
    "x2c0s3b0n0",
    "x2c0s3b0n1"
  ]
}
```
This will return (in pretty-printed JSON):
```json
[
  {
    "URI": "/hsm/v2/groups/compute/members/x1c0s1b0n0"
  },
  {
    "URI": "/hsm/v2/groups/compute/members/x1c0s1b0n1"
  },
  {
    "URI": "/hsm/v2/groups/compute/members/x2c0s3b0n0"
  },
  {
    "URI": "/hsm/v2/groups/compute/members/x2c0s3b0n1"
  }
]
```

**EDIT:** Changed case of `URI` to match from commit [`19f4e2c`](https://github.com/OpenCHAMI/smd/pull/47/commits/19f4e2c754849a7be924ec4448d86df2a3fa1887)