### PR TITLE
Changed to set the defaults at build time

### DIFF
--- a/cmd/smd/default_values_csm.go
+++ b/cmd/smd/default_values_csm.go
@@ -1,0 +1,31 @@
+// These are the default values for CSM
+//
+//go:build csm
+
+// MIT License
+//
+// (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+package main
+
+const DISABLE_DISCOVERY_DEFAULT = false
+const OPENCHAMI_DEFAULT = false
+const ZEROLOG_DEFAULT = false

--- a/cmd/smd/default_values_csm.go
+++ b/cmd/smd/default_values_csm.go
@@ -26,6 +26,6 @@
 
 package main
 
-const DISABLE_DISCOVERY_DEFAULT = false
+const ENABLE_DISCOVERY_DEFAULT = true
 const OPENCHAMI_DEFAULT = false
 const ZEROLOG_DEFAULT = false

--- a/cmd/smd/default_values_openchami.go
+++ b/cmd/smd/default_values_openchami.go
@@ -26,6 +26,6 @@
 
 package main
 
-const DISABLE_DISCOVERY_DEFAULT = true
+const ENABLE_DISCOVERY_DEFAULT = false
 const OPENCHAMI_DEFAULT = true
 const ZEROLOG_DEFAULT = true

--- a/cmd/smd/default_values_openchami.go
+++ b/cmd/smd/default_values_openchami.go
@@ -1,0 +1,31 @@
+// These are the default values for CSM
+//
+//go:build !csm
+
+// MIT License
+//
+// (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+package main
+
+const DISABLE_DISCOVERY_DEFAULT = true
+const OPENCHAMI_DEFAULT = true
+const ZEROLOG_DEFAULT = true

--- a/cmd/smd/main.go
+++ b/cmd/smd/main.go
@@ -102,21 +102,21 @@ type SmD struct {
 	dbPort    int
 	dbOpts    string
 
-	logDir           string
-	tlsCert          string
-	tlsKey           string
-	proxyURL         string
-	httpListen       string
-	msgbusListen     string
-	logLevelIn       int
-	msgbusConfig     MsgBusConfigWrapper
-	msgbusHandle     MsgbusHandleWrapper
-	hwInvHistAgeMax  int
-	smapCompEP       *SyncMap
-	genTestPayloads  string
-	disableDiscovery bool
-	openchami        bool
-	zerolog          bool
+	logDir          string
+	tlsCert         string
+	tlsKey          string
+	proxyURL        string
+	httpListen      string
+	msgbusListen    string
+	logLevelIn      int
+	msgbusConfig    MsgBusConfigWrapper
+	msgbusHandle    MsgbusHandleWrapper
+	hwInvHistAgeMax int
+	smapCompEP      *SyncMap
+	genTestPayloads string
+	enableDiscovery bool
+	openchami       bool
+	zerolog         bool
 
 	// v2 APIs
 	apiRootV2           string
@@ -211,7 +211,7 @@ func (s *SmD) Log(lvl LogLevel, format string, a ...interface{}) {
 }
 
 func (s *SmD) LogAlwaysStr(format string) {
-    s.lg.Output(2, format)
+	s.lg.Output(2, format)
 }
 
 func (s *SmD) LogAlways(format string, a ...interface{}) {
@@ -557,15 +557,15 @@ var applyMigrations bool
 
 // Parse command line options.
 func (s *SmD) parseCmdLine() {
-	disableDiscoveryDefault := DISABLE_DISCOVERY_DEFAULT
-	envvar := "DISABLE_DISCOVERY"
+	enableDiscoveryDefault := ENABLE_DISCOVERY_DEFAULT
+	envvar := "ENABLE_DISCOVERY"
 	if val := os.Getenv(envvar); val != "" {
 		b, err := strconv.ParseBool(val)
 		if err != nil {
 			fmt.Printf("Warning: Bad env %s - '%s'\n", envvar, val)
 		} else {
-			// This will be the value set to s.disableDiscovery if that flag was not passed on the command line.
-			disableDiscoveryDefault = b
+			// This is the default value for s.enableDiscovery if the cli option --enable-discovery was not used
+			enableDiscoveryDefault = b
 		}
 	}
 
@@ -595,7 +595,7 @@ func (s *SmD) parseCmdLine() {
 	flag.StringVar(&s.dbOpts, "dbopts", "", "Database options string")
 	flag.StringVar(&s.jwksURL, "jwks-url", "", "Set the JWKS URL to fetch public key for validation")
 	flag.BoolVar(&applyMigrations, "migrate", false, "Apply all database migrations before starting")
-	flag.BoolVar(&s.disableDiscovery, "disable-discovery", disableDiscoveryDefault, "Disable discovery-related subroutines")
+	flag.BoolVar(&s.enableDiscovery, "enable-discovery", enableDiscoveryDefault, "Enable discovery-related subroutines")
 	flag.BoolVar(&s.openchami, "openchami", OPENCHAMI_DEFAULT, "Enabled OpenCHAMI features")
 	flag.BoolVar(&s.zerolog, "zerolog", ZEROLOG_DEFAULT, "Enabled zerolog")
 	help := flag.Bool("h", false, "Print help and exit")
@@ -777,8 +777,8 @@ func (s *SmD) setDSN() {
 func main() {
 	PrintVersionInfo()
 
-	fmt.Printf("Build time defaults. MsgbusBuild: %t, RFEventMonitorBuild: %t, openChamiDefault: %t, zerologDefault: %t, disableDiscoveryDefault: %t\n",
-		MSG_BUS_BUILD, RF_EVENT_MONITOR_BUILD, OPENCHAMI_DEFAULT, ZEROLOG_DEFAULT, DISABLE_DISCOVERY_DEFAULT)
+	fmt.Printf("Build time defaults. MsgbusBuild: %t, RFEventMonitorBuild: %t, openChamiDefault: %t, zerologDefault: %t, enableDiscoveryDefault: %t\n",
+		MSG_BUS_BUILD, RF_EVENT_MONITOR_BUILD, OPENCHAMI_DEFAULT, ZEROLOG_DEFAULT, ENABLE_DISCOVERY_DEFAULT)
 
 	var s SmD
 	var err error
@@ -979,7 +979,7 @@ func main() {
 	s.srfpJobList = make(map[string]*Job, 0)
 	s.discMap = make(map[string]int, 0)
 	s.JobSync()
-	if !s.disableDiscovery {
+	if !s.enableDiscovery {
 		s.DiscoverySync()
 		s.DiscoveryUpdater()
 	}

--- a/cmd/smd/main_test.go
+++ b/cmd/smd/main_test.go
@@ -41,12 +41,30 @@ func TestSmdFlavor(t *testing.T) {
 		if !RF_EVENT_MONITOR_BUILD {
 			t.Errorf("SmdFlavor exepected the rf event monitor to be enabled. flavor: %s, moduleName: %s", flavor, moduleName)
 		}
+		if DISABLE_DISCOVERY_DEFAULT {
+			t.Errorf("SmdFlavor exepected DISABLE_DISCOVERY_DEFAULT to be false. flavor: %s, moduleName: %s", flavor, moduleName)
+		}
+		if OPENCHAMI_DEFAULT {
+			t.Errorf("SmdFlavor exepected OPENCHAMI_DEFAULT to be false. flavor: %s, moduleName: %s", flavor, moduleName)
+		}
+		if ZEROLOG_DEFAULT {
+			t.Errorf("SmdFlavor exepected ZEROLOG_DEFAULT to be false. flavor: %s, moduleName: %s", flavor, moduleName)
+		}
 	} else if flavor == OpenCHAMI {
 		if MSG_BUS_BUILD {
 			t.Errorf("SmdFlavor exepected the msg bus to be disabled. flavor: %s, moduleName: %s", flavor, moduleName)
 		}
 		if RF_EVENT_MONITOR_BUILD {
 			t.Errorf("SmdFlavor exepected the rf event monitor to be disabled. flavor: %s, moduleName: %s", flavor, moduleName)
+		}
+		if !DISABLE_DISCOVERY_DEFAULT {
+			t.Errorf("SmdFlavor exepected DISABLE_DISCOVERY_DEFAULT to be true. flavor: %s, moduleName: %s", flavor, moduleName)
+		}
+		if !OPENCHAMI_DEFAULT {
+			t.Errorf("SmdFlavor exepected OPENCHAMI_DEFAULT to be true. flavor: %s, moduleName: %s", flavor, moduleName)
+		}
+		if !ZEROLOG_DEFAULT {
+			t.Errorf("SmdFlavor exepected ZEROLOG_DEFAULT to be true. flavor: %s, moduleName: %s", flavor, moduleName)
 		}
 	}
 }

--- a/cmd/smd/main_test.go
+++ b/cmd/smd/main_test.go
@@ -28,43 +28,43 @@ import (
 
 func TestSmdFlavor(t *testing.T) {
 	flavor, moduleName := getSmdFlavor()
-	t.Logf("SmdFlavor values: flavor: %s, moduleName: %s", flavor, moduleName)
+	t.Logf("TestSmdFlavor values: flavor: %s, moduleName: %s", flavor, moduleName)
 
 	if flavor == UnknownSmdFlavor {
-		t.Fatalf("SmdFlavor unknown smd flavor: %s, moduleName: %s", flavor, moduleName)
+		t.Fatalf("TestSmdFlavor unknown smd flavor: %s, moduleName: %s", flavor, moduleName)
 	}
 
 	if flavor == CSM {
 		if !MSG_BUS_BUILD {
-			t.Errorf("SmdFlavor exepected the msg bus to be enabled. flavor: %s, moduleName: %s", flavor, moduleName)
+			t.Errorf("TestSmdFlavor exepected the msg bus to be enabled. flavor: %s, moduleName: %s", flavor, moduleName)
 		}
 		if !RF_EVENT_MONITOR_BUILD {
-			t.Errorf("SmdFlavor exepected the rf event monitor to be enabled. flavor: %s, moduleName: %s", flavor, moduleName)
+			t.Errorf("TestSmdFlavor exepected the rf event monitor to be enabled. flavor: %s, moduleName: %s", flavor, moduleName)
 		}
-		if DISABLE_DISCOVERY_DEFAULT {
-			t.Errorf("SmdFlavor exepected DISABLE_DISCOVERY_DEFAULT to be false. flavor: %s, moduleName: %s", flavor, moduleName)
+		if !ENABLE_DISCOVERY_DEFAULT {
+			t.Errorf("TestSmdFlavor exepected ENABLE_DISCOVERY_DEFAULT to be true. flavor: %s, moduleName: %s", flavor, moduleName)
 		}
 		if OPENCHAMI_DEFAULT {
-			t.Errorf("SmdFlavor exepected OPENCHAMI_DEFAULT to be false. flavor: %s, moduleName: %s", flavor, moduleName)
+			t.Errorf("TestSmdFlavor exepected OPENCHAMI_DEFAULT to be false. flavor: %s, moduleName: %s", flavor, moduleName)
 		}
 		if ZEROLOG_DEFAULT {
-			t.Errorf("SmdFlavor exepected ZEROLOG_DEFAULT to be false. flavor: %s, moduleName: %s", flavor, moduleName)
+			t.Errorf("TestSmdFlavor exepected ZEROLOG_DEFAULT to be false. flavor: %s, moduleName: %s", flavor, moduleName)
 		}
 	} else if flavor == OpenCHAMI {
 		if MSG_BUS_BUILD {
-			t.Errorf("SmdFlavor exepected the msg bus to be disabled. flavor: %s, moduleName: %s", flavor, moduleName)
+			t.Errorf("TestSmdFlavor exepected the msg bus to be disabled. flavor: %s, moduleName: %s", flavor, moduleName)
 		}
 		if RF_EVENT_MONITOR_BUILD {
-			t.Errorf("SmdFlavor exepected the rf event monitor to be disabled. flavor: %s, moduleName: %s", flavor, moduleName)
+			t.Errorf("TestSmdFlavor exepected the rf event monitor to be disabled. flavor: %s, moduleName: %s", flavor, moduleName)
 		}
-		if !DISABLE_DISCOVERY_DEFAULT {
-			t.Errorf("SmdFlavor exepected DISABLE_DISCOVERY_DEFAULT to be true. flavor: %s, moduleName: %s", flavor, moduleName)
+		if ENABLE_DISCOVERY_DEFAULT {
+			t.Errorf("TestSmdFlavor exepected ENABLE_DISCOVERY_DEFAULT to be false. flavor: %s, moduleName: %s", flavor, moduleName)
 		}
 		if !OPENCHAMI_DEFAULT {
-			t.Errorf("SmdFlavor exepected OPENCHAMI_DEFAULT to be true. flavor: %s, moduleName: %s", flavor, moduleName)
+			t.Errorf("TestSmdFlavor exepected OPENCHAMI_DEFAULT to be true. flavor: %s, moduleName: %s", flavor, moduleName)
 		}
 		if !ZEROLOG_DEFAULT {
-			t.Errorf("SmdFlavor exepected ZEROLOG_DEFAULT to be true. flavor: %s, moduleName: %s", flavor, moduleName)
+			t.Errorf("TestSmdFlavor exepected ZEROLOG_DEFAULT to be true. flavor: %s, moduleName: %s", flavor, moduleName)
 		}
 	}
 }

--- a/cmd/smd/smd-api.go
+++ b/cmd/smd/smd-api.go
@@ -2429,9 +2429,9 @@ func (s *SmD) doRedfishEndpointPut(w http.ResponseWriter, r *http.Request) {
 	// fail.  A manual discovery would be the recovery mechanism.
 	// TODO:  Add auto-force based on time delta.
 	//
-	// Discovery can optionally be disabled with the --disable-discovery
+	// Discovery can optionally be enabled with the --enabled-discovery
 	// flag from the CLI.
-	if !s.disableDiscovery {
+	if s.enableDiscovery {
 		go s.discoverFromEndpoint(ep, 0, false)
 	}
 
@@ -2665,9 +2665,9 @@ func (s *SmD) doRedfishEndpointsPost(w http.ResponseWriter, r *http.Request) {
 	// force this because the endpoint should always be new, else we would
 	// have already failed the operation.
 	//
-	// Discovery can optionally be disabled with the --disable-discovery
+	// Discovery can optionally be enabled with the --enable-discovery
 	// flag from the CLI.
-	if !s.disableDiscovery {
+	if s.enableDiscovery {
 		go s.discoverFromEndpoints(eps.RedfishEndpoints, 0, true, false)
 	}
 
@@ -3104,7 +3104,7 @@ func (s *SmD) parsePDUData(w http.ResponseWriter, data []byte, forceUpdate bool)
 	if _, err := s.db.UpsertComponents([]*base.Component{pduControllerComponent}, forceUpdate); err != nil {
 		err_str := fmt.Sprintf("failed to upsert PDU controller component for %s: %v", root.ID, err)
 		sendJsonError(w, http.StatusInternalServerError, err_str)
-		return fmt.Errorf(err_str)
+		return errors.New(err_str)
 	}
 	s.lg.Printf("Successfully upserted parent PDU component: %s", root.ID)
 
@@ -3190,7 +3190,7 @@ func (s *SmD) parsePDUData(w http.ResponseWriter, data []byte, forceUpdate bool)
 		if _, err := s.db.UpsertComponents(componentsToUpsert, forceUpdate); err != nil {
 			err_str := fmt.Sprintf("failed to upsert PDU outlet components for %s: %v", root.ID, err)
 			sendJsonError(w, http.StatusInternalServerError, err_str)
-			return fmt.Errorf(err_str)
+			return errors.New(err_str)
 		}
 	}
 	if len(endpointsToUpsert) > 0 {


### PR DESCRIPTION
This PR is an alternative to https://github.com/OpenCHAMI/smd/pull/61. This PR sets the default values at build time.

Added default_values_csm.go and default_values.openchami.go to contain the default constants for each platform. Which file is used is determined by a build flag.

Changed the default for disable-discovery option to be true for the OpenCHAMI build

Added env variable DISABLE_DISCOVERY which is used if --disable-discovery is not specified.

Precedence order

--disable-discovery cli argument
Environment variable DISABLE_DISCOVERY
Default value for OpenCHAMI based on the module name prefix: github.com/OpenCHAMI. The default value for OpenCHAMI is true