### PR TITLE
Add necessary fields to accept from Magellan for PCS to work

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/openchami/chi-middleware/auth v0.0.0-20240812224658-b16b83c70700
 	github.com/openchami/chi-middleware/log v0.0.0-20240812224658-b16b83c70700
-	github.com/openchami/schemas v0.0.0-20240822140637-d8f34a22a2d4
+	github.com/openchami/schemas v0.0.0-20250625220233-9aad17a286c4
 	github.com/rs/zerolog v1.33.0
 	github.com/sirupsen/logrus v1.9.3
 )
@@ -34,13 +34,13 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.0 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
-	github.com/invopop/jsonschema v0.12.0 // indirect
+	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
 	github.com/lestrrat-go/httprc v1.0.6 // indirect
 	github.com/lestrrat-go/iter v1.0.2 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
-	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/in-toto/in-toto-golang v0.5.0 h1:hb8bgwr0M2hGdDsLjkJ3ZqJ8JFLL/tgYdAxF
 github.com/in-toto/in-toto-golang v0.5.0/go.mod h1:/Rq0IZHLV7Ku5gielPT4wPHJfH1GdHMCq8+WPxw8/BE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/invopop/jsonschema v0.12.0 h1:6ovsNSuvn9wEQVOyc72aycBMVQFKz7cPdMJn10CvzRI=
-github.com/invopop/jsonschema v0.12.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
+github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
+github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
 github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -256,8 +256,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
-github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
+github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -316,8 +316,8 @@ github.com/openchami/chi-middleware/auth v0.0.0-20240812224658-b16b83c70700 h1:X
 github.com/openchami/chi-middleware/auth v0.0.0-20240812224658-b16b83c70700/go.mod h1:kswb9kU5cZAFRAvf1dAUJRWbQyjDEb0qkxW4ncDdEXg=
 github.com/openchami/chi-middleware/log v0.0.0-20240812224658-b16b83c70700 h1:Gzt5f6RK39CHvY3SJudzBb/RK4tVh/S3CpJ0eQlbNdg=
 github.com/openchami/chi-middleware/log v0.0.0-20240812224658-b16b83c70700/go.mod h1:UuXvr2loD4MtvZeKr57W0WpBs+gm0KM1kdtcXrE8M6s=
-github.com/openchami/schemas v0.0.0-20240822140637-d8f34a22a2d4 h1:XuGfSgAuuR8/TIWRDMSGF6VKSr/OMYD7kGtJSk9oemM=
-github.com/openchami/schemas v0.0.0-20240822140637-d8f34a22a2d4/go.mod h1:3dridLqXvAdO0ypPXuxnXRgaK2h/dItVKGseCgFQ13k=
+github.com/openchami/schemas v0.0.0-20250625220233-9aad17a286c4 h1:89rudSw0TeedlHbGr5L9WEW9lJ3yMEtY2EgxoC7EGso=
+github.com/openchami/schemas v0.0.0-20250625220233-9aad17a286c4/go.mod h1:3dridLqXvAdO0ypPXuxnXRgaK2h/dItVKGseCgFQ13k=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=


### PR DESCRIPTION
Resolves https://github.com/OpenCHAMI/smd/issues/63

This PR handles the new Magellan data for Power data for components, enabling power of nodes in OpenCHAMI using PCS.

Here's how I tested this:
1. build this SMD image
2. scp and load into machine
3. run in `quickstart-pcs` with this image being used in place of the upstream SMD
4. run `./magellan collect https://172.24.0.2 --username <> --password <> -v > collected.txt`
5. add BMC credentials to vault:
```
docker exec -e VAULT_TOKEN=hms -e VAULT_ADDR=http://localhost:8200/ vault sh -c 'vault kv put secret/hms-creds/x1000c1s7b0 username=<> password=<>'
docker exec -e VAULT_TOKEN=hms -e VAULT_ADDR=http://localhost:8200/ vault sh -c 'vault kv put secret/hms-creds/x1000c1s7b1 username=<> password=<>'
docker exec -e VAULT_TOKEN=hms -e VAULT_ADDR=http://localhost:8200/ vault sh -c 'vault kv put secret/hms-creds/x1000c1s7b2 username=<> password=<>'
```
6. send data to SMD `cat collected.txt | ./magellan send http://localhost:27779`
7. check data is stored correctly (showing just one BMC): `curl -sS "http://localhost:27779/hsm/v2/Inventory/ComponentEndpoints" | jq`
```
{
  "ID": "x1000c1s7b1n0",
  "Type": "Node",
  "RedfishType": "ComputerSystem",
  "RedfishSubtype": "Physical",
  "UUID": "317091ec-8be6-11e8-ab21-a4bf013f6b40",
  "OdataID": "/redfish/v1/Systems/QSBP82909087",
  "RedfishEndpointID": "x1000c1s7b1",
  "Enabled": true,
  "RedfishEndpointFQDN": "172.24.0.3",
  "RedfishURL": "172.24.0.3/redfish/v1/Systems/QSBP82909087",
  "ComponentEndpointType": "ComponentEndpointComputerSystem",
  "RedfishSystemInfo": {
    "Name": "S2600BPB",
    "Actions": {
      "#ComputerSystem.Reset": {
        "ResetType@Redfish.AllowableValues": [
          "PushPowerButton",
          "On",
          "GracefulShutdown",
          "ForceRestart",
          "Nmi",
          "ForceOn",
          "ForceOff"
        ],
        "@Redfish.ActionInfo": "https://172.24.0.3:443/redfish/v1/Systems/QSBP82909087/ResetActionInfo",
        "target": "https://172.24.0.3:443/redfish/v1/Systems/QSBP82909087/Actions/ComputerSystem.Reset"
      }
    },
    "EthernetNICInfo": [
      {
        "RedfishId": "https://172.24.0.3:443/redfish/v1/Systems/QSBP82909087/EthernetInterfaces/3",
        "@odata.id": "https://172.24.0.3:443/redfish/v1/Systems/QSBP82909087/EthernetInterfaces/3",
        "Description": "System NIC 3",
        "InterfaceEnabled": true,
        "MACAddress": "ff-ff-ff-ff-ff-ff"
      },
      {
        "RedfishId": "https://172.24.0.3:443/redfish/v1/Systems/QSBP82909087/EthernetInterfaces/1",
        "@odata.id": "https://172.24.0.3:443/redfish/v1/Systems/QSBP82909087/EthernetInterfaces/1",
        "Description": "System NIC 1",
        "InterfaceEnabled": true,
        "MACAddress": "a4-bf-01-3f-6b-40"
      },
      {
        "RedfishId": "https://172.24.0.3:443/redfish/v1/Systems/QSBP82909087/EthernetInterfaces/2",
        "@odata.id": "https://172.24.0.3:443/redfish/v1/Systems/QSBP82909087/EthernetInterfaces/2",
        "Description": "System NIC 2",
        "InterfaceEnabled": true,
        "MACAddress": "a4-bf-01-3f-6b-41"
      },
      {
        "RedfishId": "https://172.24.0.3:443/redfish/v1/Systems/QSBP82909087/EthernetInterfaces/4",
        "@odata.id": "https://172.24.0.3:443/redfish/v1/Systems/QSBP82909087/EthernetInterfaces/4",
        "Description": "System NIC 4",
        "InterfaceEnabled": true,
        "MACAddress": "02-09-01-08-38-c5"
      },
      {
        "RedfishId": "https://172.24.0.3:443/redfish/v1/Systems/QSBP82909087/EthernetInterfaces/5",
        "@odata.id": "https://172.24.0.3:443/redfish/v1/Systems/QSBP82909087/EthernetInterfaces/5",
        "Description": "System NIC 5",
        "InterfaceEnabled": true,
        "MACAddress": "02-09-01-08-46-9a"
      }
    ],
    "PowerURL": "/redfish/v1/Chassis/RackMount/Power",
    "PowerControl": [
      {
        "@odata.id": "/redfish/v1/Chassis/RackMount/Baseboard/Power#/PowerControl/0",
        "MemberId": "0",
        "Name": "System Power Control",
        "RelatedItem": [
          {
            "@odata.id": "/redfish/v1/Systems/QSBP82909087"
          },
          {
            "@odata.id": "/redfish/v1/Chassis/RackMount/Baseboard"
          }
        ]
      }
    ]
  }
}
```
8. check PCS logs: `docker logs pcs`, make sure queries working as expected
9. check status of a node
```
# curl -sS -X GET -H "Accept: application/json" http://localhost:28007/v1/power-status?xname=x1000c1s7b0n0 | jq '.'
{
  "status": [
    {
      "xname": "x1000c1s7b0n0",
      "powerState": "on",
      "managementState": "available",
      "error": "",
      "supportedPowerTransitions": [
        "On",
        "Soft-Off",
        "Off",
        "Soft-Restart",
        "Force-Off",
        "Init",
        "Hard-Restart"
      ],
      "lastUpdated": "2025-06-26T23:09:51.516396198Z"
    }
  ]
}
```
10. make sure I can send a transition
```
# curl -sS -X POST -H "Content-Type: application/json" -H "Accept: application/json" -d '{"operation": "on", "location": [{"xname": "x1000c1s7b1n0"}]}' http://localhost:28007/v1/transitions | jq '.'
{
  "transitionID": "f6a512bc-cfcb-4f99-9900-2ea320160468",
  "operation": "On"
}
# curl -sS -X GET -H "Accept: application/json" http://localhost:28007/v1/transitions/f6a512bc-cfcb-4f99-9900-2ea320160468 | jq '.'
{
  "transitionID": "f6a512bc-cfcb-4f99-9900-2ea320160468",
  "operation": "On",
  "createTime": "2025-06-26T23:10:41.23009216Z",
  "automaticExpirationTime": "2025-06-27T23:10:41.230092371Z",
  "transitionStatus": "completed",
  "taskCounts": {
    "total": 1,
    "new": 0,
    "in-progress": 0,
    "failed": 0,
    "succeeded": 1,
    "un-supported": 0
  },
  "tasks": [
    {
      "xname": "x1000c1s7b1n0",
      "taskStatus": "succeeded",
      "taskStatusDescription": "Component already in desired state"
    }
  ]
}
```