### PR TITLE
Add support for parsing and storing PDU endpoints

### DIFF
--- a/internal/hmsds/hmsds-api-filters.go
+++ b/internal/hmsds/hmsds-api-filters.go
@@ -51,29 +51,28 @@ type PCondition struct {
 
 type ComponentFilter struct {
 	// User-writable options
-	ID        []string `json:"id"`
-	NID       []string `json:"nid"`
-	NIDStart  []string `json:"nid_start"`
-	NIDEnd    []string `json:"nid_end"`
-	Type      []string `json:"type"`
-	State     []string `json:"state"`
-	Flag      []string `json:"flag"`
-	Enabled   []string `json:"enabled"`
-	SwStatus  []string `json:"softwarestatus"`
-	Role      []string `json:"role"`
-	SubRole   []string `json:"subrole"`
-	Subtype   []string `json:"subtype"`
-	Arch      []string `json:"arch"`
-	Class     []string `json:"class"`
-	Group     []string `json:"group"` // Arbitrary Groups have UUID ids as well as globally unique names
-	Partition []string `json:"partition"`
-	Locked    []string `json:"locked"`
+	ID                  []string `json:"id"`
+	NID                 []string `json:"nid"`
+	NIDStart            []string `json:"nid_start"`
+	NIDEnd              []string `json:"nid_end"`
+	Type                []string `json:"type"`
+	State               []string `json:"state"`
+	Flag                []string `json:"flag"`
+	Enabled             []string `json:"enabled"`
+	SwStatus            []string `json:"softwarestatus"`
+	Role                []string `json:"role"`
+	SubRole             []string `json:"subrole"`
+	Subtype             []string `json:"subtype"`
+	Arch                []string `json:"arch"`
+	Class               []string `json:"class"`
+	Group               []string `json:"group"` // Arbitrary Groups have UUID ids as well as globally unique names
+	Partition           []string `json:"partition"`
+	Locked              []string `json:"locked"`
 	ReservationDisabled []string `json:"reservation_disabled"`
 
 	// private options
 	writeLock bool   // default is false
 	label     string // Labels query for logging, etc.
-	skipValidation bool
 
 	// State OR flag subclause without ORing the whole query.  For the
 	// target state and clause, since one or the other can be right but
@@ -88,7 +87,7 @@ type ComponentFilter struct {
 
 	// Same thing is needed to find components whose role or subrole differ
 	// from the desired values
-	orRole []string
+	orRole    []string
 	orSubRole []string
 
 	flagCondition *PCondition
@@ -216,8 +215,9 @@ type CompFiltFunc func(*ComponentFilter)
 // negated with "!" and all such ids will be excluded.
 //
 // NOTE: will add the empty string if ids is zero length to select no ids.
-//       The assumption is that this isn't being used to select any ID as
-//       this option would be unneccessary otherwise.
+//
+//	The assumption is that this isn't being used to select any ID as
+//	this option would be unneccessary otherwise.
 func IDs(ids []string) CompFiltFunc {
 	return func(f *ComponentFilter) {
 		if f != nil {
@@ -228,16 +228,6 @@ func IDs(ids []string) CompFiltFunc {
 			}
 		}
 	}
-}
-
-// SkipValidation is a CompFiltFunc that tells the database query
-// to not normalize or validate component IDs.
-func SkipValidation() CompFiltFunc {
-    return func(f *ComponentFilter) {
-        if f != nil {
-            f.skipValidation = true
-        }
-    }
 }
 
 // Filter includes just this id.  Overwrites other ID calls.
@@ -504,7 +494,7 @@ func (f *ComponentFilter) VerifyNormalize() error {
 	if err != nil {
 		return ErrHMSDSArgBadFlag
 	}
-	err = checkFilterField(f.orRole,  base.VerifyNormalizeRole, true)
+	err = checkFilterField(f.orRole, base.VerifyNormalizeRole, true)
 	if err != nil {
 		return ErrHMSDSArgBadRole
 	}
@@ -618,8 +608,9 @@ type CompEPFiltFunc func(*CompEPFilter)
 // negated with "!" and all such ids will be excluded.
 //
 // NOTE: will add the empty string if ids is zero length to select no ids.
-//       The assumption is that this isn't being used to select any ID as
-//       this option would be unneccessary otherwise.
+//
+//	The assumption is that this isn't being used to select any ID as
+//	this option would be unneccessary otherwise.
 func CE_IDs(ids []string) CompEPFiltFunc {
 	return func(f *CompEPFilter) {
 		if f != nil {
@@ -708,8 +699,9 @@ type RedfishEPFiltFunc func(*RedfishEPFilter)
 // negated with "!" and all such ids will be excluded.
 //
 // NOTE: will add the empty string if ids is zero length to select no ids.
-//       The assumption is that this isn't being used to select any ID as
-//       this option would be unneccessary otherwise.
+//
+//	The assumption is that this isn't being used to select any ID as
+//	this option would be unneccessary otherwise.
 func RFE_IDs(ids []string) RedfishEPFiltFunc {
 	return func(f *RedfishEPFilter) {
 		if f != nil {
@@ -989,8 +981,9 @@ type HWInvLocFiltFunc func(*HWInvLocFilter)
 // negated with "!" and all such ids will be excluded.
 //
 // NOTE: will add the empty string if ids is zero length to select no ids.
-//       The assumption is that this isn't being used to select any ID as
-//       this option would be unneccessary otherwise.
+//
+//	The assumption is that this isn't being used to select any ID as
+//	this option would be unneccessary otherwise.
 func HWInvLoc_IDs(ids []string) HWInvLocFiltFunc {
 	return func(f *HWInvLocFilter) {
 		if f != nil {
@@ -1134,8 +1127,9 @@ type HWInvHistFiltFunc func(*HWInvHistFilter)
 // negated with "!" and all such ids will be excluded.
 //
 // NOTE: will add the empty string if ids is zero length to select no ids.
-//       The assumption is that this isn't being used to select any ID as
-//       this option would be unneccessary otherwise.
+//
+//	The assumption is that this isn't being used to select any ID as
+//	this option would be unneccessary otherwise.
 func HWInvHist_IDs(ids []string) HWInvHistFiltFunc {
 	return func(f *HWInvHistFilter) {
 		if f != nil {
@@ -1227,8 +1221,9 @@ type CompEthInterfaceFiltFunc func(*CompEthInterfaceFilter)
 // negated with "!" and all such ids will be excluded.
 //
 // NOTE: will add the empty string if ids is zero length to select no ids.
-//       The assumption is that this isn't being used to select any ID as
-//       this option would be unneccessary otherwise.
+//
+//	The assumption is that this isn't being used to select any ID as
+//	this option would be unneccessary otherwise.
 func CEI_IDs(ids []string) CompEthInterfaceFiltFunc {
 	return func(f *CompEthInterfaceFilter) {
 		if f != nil {

--- a/internal/hmsds/hmsds-api.go
+++ b/internal/hmsds/hmsds-api.go
@@ -213,7 +213,7 @@ type HMSDB interface {
 	// all-or-none transaction. If force=true, only the state, flag, subtype,
 	// nettype, and arch will be overwritten for existing components. Otherwise,
 	// this won't overwrite existing components.
-	UpsertComponents(comps []*base.Component, force bool, skipValidation bool) (map[string]map[string]bool, error)
+	UpsertComponents(comps []*base.Component, force bool) (map[string]map[string]bool, error)
 
 	// Update state and flag fields only in DB for the given IDs.  If
 	// len(ids) is > 1 a locking read will be done to ensure the list o
@@ -555,7 +555,7 @@ type HMSDB interface {
 	GetCompEndpointsFilter(f *CompEPFilter) ([]*sm.ComponentEndpoint, error)
 
 	// Upsert ComponentEndpoint into database, updating it if it exists.
-	UpsertCompEndpoint(cep *sm.ComponentEndpoint, skipValidation bool) error
+	UpsertCompEndpoint(cep *sm.ComponentEndpoint) error
 
 	// Upsert ComponentEndpointArray into database within a single all-or-none
 	// transaction.
@@ -1025,11 +1025,11 @@ type HMSDBTx interface {
 
 	// Insert HMS Component into database, updating it if it exists.
 	// Returns the number of affected rows. < 0 means RowsAffected() is not supported.
-	InsertComponentTx(c *base.Component, skipValidation bool) (int64, error)
+	InsertComponentTx(c *base.Component) (int64, error)
 
 	// Insert HMS Components into the database, updating it if it exists.
 	// Returns the IDs of the affected components.
-	InsertComponentsTx(comps []*base.Component, skipValidation bool) ([]string, error)
+	InsertComponentsTx(comps []*base.Component) ([]string, error)
 
 	// Update state and flag fields only in DB for xname IDs 'ids'
 	// If force = true ignores any starting state restrictions and will always
@@ -1338,7 +1338,7 @@ type HMSDBTx interface {
 
 	// Upsert ComponentEndpoint into database, updating it if it exists
 	// (in transaction)
-	UpsertCompEndpointTx(cep *sm.ComponentEndpoint, skipValidation bool) error
+	UpsertCompEndpointTx(cep *sm.ComponentEndpoint) error
 
 	// Upsert ComponentEndpoints into database, updating them if they exist
 	// (in transaction)

--- a/internal/hmsds/query-shared-sq.go
+++ b/internal/hmsds/query-shared-sq.go
@@ -102,7 +102,7 @@ var compGroupPartCols = []string{
 // Queries for various Components column filter options
 //
 
-//  FLTR_DEFAULT
+// FLTR_DEFAULT
 var compColsDefault = []string{
 	compIdCol,
 	compTypeCol,
@@ -121,7 +121,7 @@ var compColsDefault = []string{
 	compLockedCol,
 }
 
-//	FLTR_STATEONLY
+// FLTR_STATEONLY
 var compColsStateOnly = []string{
 	compIdCol,
 	compTypeCol,
@@ -129,14 +129,14 @@ var compColsStateOnly = []string{
 	compFlagCol,
 }
 
-//	FLTR_FLAGONLY
+// FLTR_FLAGONLY
 var compColsFlagOnly = []string{
 	compIdCol,
 	compTypeCol,
 	compFlagCol,
 }
 
-//	FLTR_ROLEONLY
+// FLTR_ROLEONLY
 var compColsRoleOnly = []string{
 	compIdCol,
 	compTypeCol,
@@ -144,14 +144,14 @@ var compColsRoleOnly = []string{
 	compSubRoleCol,
 }
 
-//	FLTR_NIDONLY
+// FLTR_NIDONLY
 var compColsNIDOnly = []string{
 	compIdCol,
 	compTypeCol,
 	compNIDCol,
 }
 
-//	FLTR_ID_ONLY
+// FLTR_ID_ONLY
 var compColsIdOnly = []string{
 	compIdCol,
 }
@@ -159,11 +159,11 @@ var compColsIdOnly = []string{
 // These two combine group-related columns in addition to the standard
 // Component ones.
 
-//	FLTR_ALL_W_GROUP
+// FLTR_ALL_W_GROUP
 var compColsAllWithGroup1 []string = compColsDefault
 var compColsAllWithGroup2 []string = compGroupPartCols
 
-//	FLTR_ID_W_GROUP
+// FLTR_ID_W_GROUP
 var compColsIdWithGroup1 []string = compColsIdOnly
 var compColsIdWithGroup2 []string = compGroupPartCols
 
@@ -280,20 +280,20 @@ const compResTable = `reservations`
 const compResAlias = `cr` // used during joins, i.e. cr.component.id
 
 const (
-	compResCompIdCol   = `component_id`
-	compResCreatedCol  = `create_timestamp`
-	compResExpireCol   = `expiration_timestamp`
-	compResDKCol       = `deputy_key`
-	compResRKCol       = `reservation_key`
+	compResCompIdCol  = `component_id`
+	compResCreatedCol = `create_timestamp`
+	compResExpireCol  = `expiration_timestamp`
+	compResDKCol      = `deputy_key`
+	compResRKCol      = `reservation_key`
 )
 
 // This adds the base table alias to each column.  it can later be appended to.
 const (
-	compResCompIdColAlias   = compResAlias + "." + compResCompIdCol
-	compResCreatedColAlias  = compResAlias + "." + compResCreatedCol
-	compResExpireColAlias   = compResAlias + "." + compResExpireCol
-	compResDKColAlias       = compResAlias + "." + compResDKCol
-	compResRKColAlias       = compResAlias + "." + compResRKCol
+	compResCompIdColAlias  = compResAlias + "." + compResCompIdCol
+	compResCreatedColAlias = compResAlias + "." + compResCreatedCol
+	compResExpireColAlias  = compResAlias + "." + compResExpireCol
+	compResDKColAlias      = compResAlias + "." + compResDKCol
+	compResRKColAlias      = compResAlias + "." + compResRKCol
 )
 
 // reservations table columns.
@@ -941,11 +941,9 @@ func makeComponentQuery(alias string, f *ComponentFilter, fltr FieldFilter) (
 	if f != nil {
 		// Check and normalize filter inputs, skipping if this has
 		// already been done.
-		if !f.skipValidation {
-            if err := f.VerifyNormalize(); err != nil {
-                return query, err
-            }
-        }
+		if err := f.VerifyNormalize(); err != nil {
+			return query, err
+		}
 	}
 	// Add the base query opts - Note the order doesn't have to match the
 	// sql statement.


### PR DESCRIPTION
This PR implements this portion:
> SMD Data Ingestion
Develop a new function in SMD (e.g., a parseJawsEndpointData function) to receive and process PDU inventory from Magellan
Ensure this function correctly creates or updates Component Endpoint entries in SMD, representing the PDU and its controllable outlets, with appropriate Redfish-like attributes

of this issue: https://github.com/OpenCHAMI/magellan/issues/100

This updates UpsertComponents and UpsertCompEndpoints to accept PDU components. This required a special `skipValidation` argument to be threaded through, since PDUs don't always match standard xname convention.

Here is some sample output on real data incorporating the Magellan changes:
By running this command: 

```
./magellan-linux collect pdu <pdu-hostname> --username <pdu-username> --password <pdu-password>
```

the user is able to gather information for the PDU to be sent with `magellan send` for storage in SMD.

For example:
```
./magellan collect pdu x3000m0 --username admn --password admn | ./magellan send http://localhost:27779
```

which will generate:
```
[
  {
    "Enabled": true,
    "FQDN": "x3000m0",
    "Hostname": "x3000m0",
    "ID": "x3000m0",
    "RediscoverOnUpdate": false,
    "PDUInventory": {
      "Outlets": [
        {
          "id": "AA1",
          "name": "Master_Outlet_1",
          "socket_type": "Cx",
          "state": "On"
        },
        {
          "id": "AA2",
          "name": "Master_Outlet_2",
          "socket_type": "Cx",
          "state": "On"
        },
        {
          "id": "AA3",
          "name": "Master_Outlet_3",
          "socket_type": "Cx",
          "state": "On"
        },
        // ...truncated
```

Which can then be stored in SMD as:
Output from # curl -sS -H "Accept: application/json" http://localhost:27779/hsm/v2/Inventory/RedfishEndpoints | jq
```
{
  "RedfishEndpoints": [
    {
      "ID": "x3000m0",
      "Type": "CabinetPDUController",
      "Hostname": "x3000m0",
      "Domain": "",
      "FQDN": "x3000m0",
      "Enabled": true,
      "User": "",
      "Password": "",
      "RediscoverOnUpdate": false,
      "DiscoveryInfo": {
        "LastDiscoveryStatus": "NotYetQueried"
      }
    }
  ]
}
```

Truncated output from curl -sS "http://localhost:27779/hsm/v2/Inventory/ComponentEndpoints" | jq:
```
    {
      "ID": "x3000m0BA35",
      "Type": "CabinetPDUPowerConnector",
      "RedfishType": "Outlet",
      "RedfishSubtype": "Cx",
      "OdataID": "/jaws/control/outlets/BA35",
      "RedfishEndpointID": "x3000m0",
      "Enabled": true,
      "RedfishEndpointFQDN": "x3000m0",
      "RedfishURL": "x3000m0/jaws/control/outlets/BA35",
      "ComponentEndpointType": "ComponentEndpointOutlet",
      "RedfishOutletInfo": {
        "Name": "Link1_Outlet_35",
        "Actions": {
          "#Outlet.PowerControl": {
            "PowerState@Redfish.AllowableValues": [
              "On",
              "Off"
            ],
            "target": "/jaws/control/outlets/BA35"
          }
        }
      }
    },
    {
      "ID": "x3000m0BA36",
      "Type": "CabinetPDUPowerConnector",
      "RedfishType": "Outlet",
      "RedfishSubtype": "Cx",
      "OdataID": "/jaws/control/outlets/BA36",
      "RedfishEndpointID": "x3000m0",
      "Enabled": true,
      "RedfishEndpointFQDN": "x3000m0",
      "RedfishURL": "x3000m0/jaws/control/outlets/BA36",
      "ComponentEndpointType": "ComponentEndpointOutlet",
      "RedfishOutletInfo": {
        "Name": "Link1_Outlet_36",
        "Actions": {
          "#Outlet.PowerControl": {
            "PowerState@Redfish.AllowableValues": [
              "On",
              "Off"
            ],
            "target": "/jaws/control/outlets/BA36"
          }
        }
      }
    }
  ]
}
```

Related to https://github.com/OpenCHAMI/magellan/pull/103