### PR TITLE
Add migration to prune duplicate "Detected" events from CPUs and GPUs

### DIFF
--- a/migrations/postgres/20_fru_history_prune_version18.up.sql
+++ b/migrations/postgres/20_fru_history_prune_version18.up.sql
@@ -40,6 +40,9 @@ BEGIN
     FOR comp_id IN SELECT distinct id FROM hwinv_hist LOOP
         SELECT * INTO fru_event1 FROM hwinv_hist WHERE id = comp_id.id ORDER BY timestamp ASC LIMIT 1;
         FOR fru_event2 IN SELECT * FROM hwinv_hist WHERE id = comp_id.id AND timestamp != fru_event1.timestamp ORDER BY timestamp ASC LOOP
+            -- TODO: Shouldn't this IF statement also check that the
+            --       event_type is the same?  Otherwise we'll be pruning
+            --       out unique events that haven't repeated?
             IF fru_event2.fru_id = fru_event1.fru_id THEN
                 DELETE FROM hwinv_hist WHERE id = fru_event2.id AND fru_id = fru_event2.fru_id AND timestamp = fru_event2.timestamp;
             ELSE

--- a/migrations/postgres/23_fru_history_remove_duplicate_detected_events.down.sql
+++ b/migrations/postgres/23_fru_history_remove_duplicate_detected_events.down.sql
@@ -1,0 +1,33 @@
+/*
+ * MIT License
+ *
+ * (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+-- Removes function and index that removes duplicate detected events from
+-- the hardware history table.
+
+DROP INDEX IF EXISTS hwinvhist_id_ts_idx;
+
+DROP FUNCTION hwinv_hist_remove_duplicate_detected_events();
+
+-- Decrease the schema version
+INSERT INTO system VALUES(0, 20, '{}'::JSON)
+    ON CONFLICT(id) DO UPDATE SET schema_version=20;

--- a/migrations/postgres/23_fru_history_remove_duplicate_detected_events.up.sql
+++ b/migrations/postgres/23_fru_history_remove_duplicate_detected_events.up.sql
@@ -1,0 +1,72 @@
+/*
+ * MIT License
+ *
+ * (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+-- Removes duplicate "Detected" events from the hardware history table
+
+CREATE OR REPLACE FUNCTION hwinv_hist_remove_duplicate_detected_events()
+RETURNS VOID AS $$
+BEGIN
+    -- Creating this index speeds up execution by several orders of magnitude
+
+    CREATE INDEX IF NOT EXISTS hwinvhist_id_ts_idx ON hwinv_hist (id, "timestamp");
+
+    -- Run the pruning logic
+
+    WITH ordered AS (
+        -- Build a temporary view of all events, ordered by time per device (id)
+        SELECT ctid, id, "timestamp", event_type,
+                -- For each event, get the previous event type for the same id
+                LAG(event_type) OVER (PARTITION BY id ORDER BY "timestamp") AS prev_type
+        FROM hwinv_hist
+        WHERE id IN (
+            -- Limit to CPUs and GPUs only
+            SELECT loc.id
+            FROM hwinv_by_loc loc
+            WHERE loc.type IN ('Processor', 'NodeAccel')
+        )
+    ),
+    dups AS (
+        -- Identify rows where both this and previous event are "Detected" for the same id
+        SELECT ctid
+        FROM ordered
+        WHERE event_type = 'Detected' AND prev_type = 'Detected'
+    )
+
+    -- Now delete the rows that have been identified as duplicates
+
+    DELETE FROM hwinv_hist
+    WHERE ctid IN (SELECT ctid FROM dups);
+END;
+$$ LANGUAGE plpgsql;
+
+-- Execute the pruning function
+
+SELECT hwinv_hist_remove_duplicate_detected_events();
+
+-- A full vacuum must be run to reclaim space but cannot run from a migration.
+-- The cray-smd-init service will run it manually after the migration completes.
+
+-- Bump the schema version
+insert into system values(0, 21, '{}'::JSON)
+    on conflict(id) do update set schema_version=21;

--- a/scripts/hwinv_by_loc_backup.sh
+++ b/scripts/hwinv_by_loc_backup.sh
@@ -1,0 +1,51 @@
+#! /usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# This script backs up the hwinv_by_loc table in the SMD postgres database.
+
+set -eo pipefail
+
+DB_NAME="hmsds"
+DB_USER="postgres"
+DB_TABLE="hwinv_by_loc"
+
+BACKUP_FILE="smd_hwinv_by_loc_table_backup-$(date +"%m%d%Y-%H:%M:%S").sql"
+
+# Determine the SMD postgres leader
+
+echo "Determining the postgres leader..."
+
+POSTGRES_LEADER=$(kubectl exec cray-smd-postgres-0 -n services -c postgres -t -- patronictl list -f json | jq -r '.[] | select(.Role == "Leader").Member')
+
+echo "The SMD postgres leader is $POSTGRES_LEADER"
+
+# Dump the contents of the hwinv_by_loc table.  We use --clean so that
+# the dump file can be used to replace the table contents if necessary
+# during a restore operation in the future if necessary
+
+echo "Using pg_dump to dump the $DB_TABLE table..."
+
+kubectl -n services exec "$POSTGRES_LEADER" -c postgres -it -- bash -c "pg_dump -U $DB_USER -d $DB_NAME -t $DB_TABLE --clean" > "$BACKUP_FILE"
+
+echo "Dump complete. Dump file is: $BACKUP_FILE"


### PR DESCRIPTION
- Added a migration to prune duplicate "Detected" events from CPUs and GPUs
- This change was first made on the CSM and cherry picked into OpenCHAMI

These changes were first made in CSM. The changes are related to cleaning up
duplicate events in the FRU tracking data.

(cherry picked from commit cc60464ed00bdf03488cba2f01b59d5d2d9e7ddb)