### PR TITLE
Added drain and close to doGroupMembersPut

### DIFF
--- a/cmd/smd/smd-api.go
+++ b/cmd/smd/smd-api.go
@@ -5128,6 +5128,7 @@ func (s *SmD) doGroupMembersPost(w http.ResponseWriter, r *http.Request) {
 // already exist in the group, they are added to the group. Any xnames that
 // exist in the group that are not in the payload are removed from the group.
 func (s *SmD) doGroupMembersPut(w http.ResponseWriter, r *http.Request) {
+	defer base.DrainAndCloseRequestBody(r)
 	var membersIn sm.MemberPutBody
 
 	label := sm.NormalizeGroupField(chi.URLParam(r, "group_label"))


### PR DESCRIPTION
SMD leaks memory if the request is not fully read and closed. The DrainAndCloseRequestBody function was created to do this. This change adds a call to this in doGroupMembersPut.

I tested this using the quickstart guide, and made calls like the following
```
curl -s -X POST -H "Authorization: Bearer $ACCESS_TOKEN" -d '{"label": "fish", "description": "a fish", "members": {"IDs": ["x1000c1s7b0", "x1000c1s7b1"]}}' http://smd:27779/hsm/v2/groups | jq

curl -s -X GET -H "Authorization: Bearer $ACCESS_TOKEN" http://smd:27779/hsm/v2/groups/fish | jq
curl -s -X GET -H "Authorization: Bearer $ACCESS_TOKEN" http://smd:27779/hsm/v2/groups/fish/members | jq

curl -s -X PUT -H "Authorization: Bearer $ACCESS_TOKEN" -d '{"Group": "fish", "IDs": ["x1000c1s7b1", "x1000c1s7b2"]}' http://smd:27779/hsm/v2/groups/fish/members | jq
```