### PR TITLE
Add support back for routing to old parseRedfishEndpoints when no schema present

### DIFF
--- a/cmd/smd/smd-api.go
+++ b/cmd/smd/smd-api.go
@@ -2693,11 +2693,19 @@ func (s *SmD) doRedfishEndpointsPost(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if s.openchami {
 			s.lg.Printf("Payload does not contain PDUInventory key, routing to default V2 parser.")
-			if s.getSchemaVersion(w, body) > 0 { // Simplified from original
+			schemaVersion := s.getSchemaVersion(w, body)
+			if schemaVersion > 0 { 
 				err = s.parseRedfishEndpointDataV2(w, body, false)
 				if err != nil {
 					sendJsonError(w, http.StatusInternalServerError,
 						fmt.Sprintf("failed parsing post data (V2): %v", err))
+				}
+			} else {-
+				// This routes legacy requests (schemaVersion <= 0) to the old parser
+				err = s.parseRedfishEndpointData(w, eps, body) 
+				if err != nil {
+					sendJsonError(w, http.StatusInternalServerError,
+						fmt.Sprintf("failed parsing post data: %v", err))
 				}
 			}
 		}

--- a/cmd/smd/smd-api.go
+++ b/cmd/smd/smd-api.go
@@ -2700,7 +2700,7 @@ func (s *SmD) doRedfishEndpointsPost(w http.ResponseWriter, r *http.Request) {
 					sendJsonError(w, http.StatusInternalServerError,
 						fmt.Sprintf("failed parsing post data (V2): %v", err))
 				}
-			} else {-
+			} else {
 				// This routes legacy requests (schemaVersion <= 0) to the old parser
 				err = s.parseRedfishEndpointData(w, eps, body) 
 				if err != nil {


### PR DESCRIPTION
Chris pointed out an issue where I had removed logic for the legacy parser in https://github.com/OpenCHAMI/smd/commit/acd7bf0fabaed121c089cae51a8629b2f9021aa2. I had made the incorrect assumption in that change that we no longer care about that function, so I'm restoring the old functionality here.
