### PR TITLE
Allow a custom HTTP client to be used with ServiceReservation

### DIFF
--- a/pkg/service-reservations/interface.go
+++ b/pkg/service-reservations/interface.go
@@ -97,6 +97,9 @@ type ServiceReservation interface {
 
 	InitInstance(stateManagerServer string, reservationPath string, defaultTermMinutes int, logger *logrus.Logger, svcName string)
 
+	//Initialize with a custom http client (for example with OAuth2 transport)
+	InitWithHTTPClient(stateManagerServer string, reservationPath string, defaultTermMinutes int, logger *logrus.Logger, svcName string, httpClient *retryablehttp.Client)
+
 	//Try to aquire locks for a list of xnames, renewing them within 30 seconds of expiration.
 	Aquire(xnames []string) error
 
@@ -177,6 +180,12 @@ func (i *Production) Init(stateManagerServer string, reservationPath string, def
 func (i *Production) InitInstance(stateManagerServer string, reservationPath string, defaultTermMinutes int, logger *logrus.Logger, svcName string) {
 	serviceName = svcName
 	i.Init(stateManagerServer, reservationPath, defaultTermMinutes, logger)
+}
+
+// Initialize with a custom http client (for example with OAuth2 transport)
+func (i *Production) InitWithHTTPClient(stateManagerServer string, reservationPath string, defaultTermMinutes int, logger *logrus.Logger, svcName string, httpClient *retryablehttp.Client) {
+	i.InitInstance(stateManagerServer, reservationPath, defaultTermMinutes, logger, svcName)
+	i.httpClient = httpClient
 }
 
 // Lets make this really simple; Im going to wake up and see what expires in the next 30 seconds;


### PR DESCRIPTION
### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [ ] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [ ] **REUSE Compliance**:  
- [ ] Each new/modified source file has SPDX copyright and license headers  
- [ ] Any non-commentable files include a `<filename>.license` sidecar  
- [ ] All referenced licenses are present in the `LICENSES/` directory  

### Description

PCS uses the `ServiceReservation` interface to make reservations, we need to be able to initialize it with custom HTTP client which has an OAuth2 transport enabled.

### Type of Change

- [ ] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
