### PR TITLE
Use default db port if one is not specified.

### DIFF
--- a/cmd/smd-init/main.go
+++ b/cmd/smd-init/main.go
@@ -96,21 +96,19 @@ func parseCmdLine() {
 	if dbPortStr == "" {
 		if val := os.Getenv(envvar); val != "" {
 			dbPortStr = val
+		} else {
+			dbPortStr = "5432"
 		}
 	}
-	if dbPortStr == "" {
-		lg.Printf("Missing DB port number")
+
+	port, err := strconv.ParseInt(dbPortStr, 10, 64)
+	if err != nil {
+		lg.Printf("Bad dbport '%s': %s", dbPortStr, err)
 		flag.Usage()
 		os.Exit(1)
-	} else {
-		port, err := strconv.ParseInt(dbPortStr, 10, 64)
-		if err != nil {
-			lg.Printf("Bad dbport '%s': %s", dbPortStr, err)
-			flag.Usage()
-			os.Exit(1)
-		}
-		dbPort = int(port)
 	}
+	dbPort = int(port)
+	
 	envvar = "SMD_DBOPTS"
 	if dbOpts == "" {
 		if val := os.Getenv(envvar); val != "" {

--- a/cmd/smd/main.go
+++ b/cmd/smd/main.go
@@ -653,6 +653,8 @@ func (s *SmD) parseCmdLine() {
 	if s.dbPortStr == "" {
 		if val := os.Getenv(envvar); val != "" {
 			s.dbPortStr = val
+		} else {
+			s.dbPortStr = "5432"
 		}
 	}
 	envvar = "SMD_JWKS_URL"
@@ -662,19 +664,14 @@ func (s *SmD) parseCmdLine() {
 		}
 	}
 
-	if s.dbPortStr == "" {
-		fmt.Printf("Missing DB port number")
+	port, err := strconv.ParseInt(s.dbPortStr, 10, 64)
+	if err != nil {
+		fmt.Printf("Bad dbport '%s': %s", s.dbPortStr, err)
 		flag.Usage()
 		os.Exit(1)
-	} else {
-		port, err := strconv.ParseInt(s.dbPortStr, 10, 64)
-		if err != nil {
-			fmt.Printf("Bad dbport '%s': %s", s.dbPortStr, err)
-			flag.Usage()
-			os.Exit(1)
-		}
-		s.dbPort = int(port)
 	}
+	s.dbPort = int(port)
+
 	envvar = "SMD_DBOPTS"
 	if s.dbOpts == "" {
 		if val := os.Getenv(envvar); val != "" {


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [ ] **REUSE Compliance**:  
  - [ ] Each new/modified source file has SPDX copyright and license headers  
  - [ ] Any non-commentable files include a `<filename>.license` sidecar  
  - [ ] All referenced licenses are present in the `LICENSES/` directory  

### Description

The documentation indicates that SMD_DBHOST has a [default port of 5432](https://github.com/OpenCHAMI/smd/blob/63e15b2c0675bfd64459d1d49f1ab03ac5717d87/README.md?plain=1#L132), but if it is not specified on the command line or environment the command will error out and print usage. This change just sets the default port if not otherwise set.

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
