### PR TITLE
fix: make the 404 handler handle 404s instead of feeding loggers to the GC

### DIFF
--- a/cmd/smd/routers.go
+++ b/cmd/smd/routers.go
@@ -58,9 +58,7 @@ func (s *SmD) NewRouter(publicRoutes []Route, protectedRoutes []Route) *chi.Mux 
 	router.Use(middleware.Recoverer)
 	router.Use(middleware.StripSlashes)
 	router.Use(openchami_logger.OpenCHAMILogger(logger))
-	router.NotFound(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		s.Logger(http.NotFoundHandler(), "NotFoundHandler")
-	}))
+	router.NotFound(http.HandlerFunc(s.Logger(http.NotFoundHandler(), "NotFoundHandler").ServeHTTP))
 
 	router.Use(middleware.Timeout(60 * time.Second))
 	if s.IsUsingAuthentication() {

--- a/cmd/smd/smd-api_test.go
+++ b/cmd/smd/smd-api_test.go
@@ -796,10 +796,6 @@ func TestDoReadyGet(t *testing.T) {
 
 		router.ServeHTTP(w, req)
 
-		if test.hmsdsRespErr != err {
-			t.Errorf("Request error was invalid, wanted '%v' and got '%v'", test.hmsdsRespErr, err)
-		}
-
 		if test.expectedStatus != w.Code {
 			t.Errorf("Response code was %v; expected an %v", w.Code, test.expectedStatus)
 		}

--- a/cmd/smd/smd-api_test.go
+++ b/cmd/smd/smd-api_test.go
@@ -38,11 +38,11 @@ import (
 	base "github.com/Cray-HPE/hms-base/v2"
 	compcreds "github.com/Cray-HPE/hms-compcredentials"
 	sstorage "github.com/Cray-HPE/hms-securestorage"
+	"github.com/Cray-HPE/hms-xname/xnametypes"
 	"github.com/OpenCHAMI/smd/v2/internal/hmsds"
 	rf "github.com/OpenCHAMI/smd/v2/pkg/redfish"
 	stest "github.com/OpenCHAMI/smd/v2/pkg/sharedtest"
 	"github.com/OpenCHAMI/smd/v2/pkg/sm"
-	"github.com/Cray-HPE/hms-xname/xnametypes"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -761,20 +761,29 @@ func TestNidRangeToCompFilter(t *testing.T) {
 
 func TestDoReadyGet(t *testing.T) {
 	tests := []struct {
-		reqType      string
-		reqURI       string
-		hmsdsRespErr error
-		expectedResp []byte
+		reqType        string
+		reqURI         string
+		hmsdsRespErr   error
+		expectedResp   []byte
+		expectedStatus int
 	}{{
 		"GET",
 		"https://localhost/hsm/v2/service/ready",
 		nil,
 		json.RawMessage(`{"code":0,"message":"HSM is healthy"}` + "\n"),
+		200,
 	}, {
 		"GET",
 		"https://localhost/hsm/v2/service/ready",
 		hmsds.ErrHMSDSPtrClosed,
 		json.RawMessage(`{"type":"about:blank","title":"Service Unavailable","detail":"HSM's database is unhealthy: HMSDS handle is not open.","status":503}` + "\n"),
+		503,
+	}, {
+		"GET",
+		"https://localhost/hsm/v2/path-that-doesnt-exist",
+		nil,
+		[]byte("404 page not found\n"),
+		404,
 	}}
 
 	for i, test := range tests {
@@ -786,13 +795,16 @@ func TestDoReadyGet(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		router.ServeHTTP(w, req)
-		if test.hmsdsRespErr == nil && w.Code != http.StatusOK {
-			t.Errorf("Response code was %v; want 204", w.Code)
-		} else if test.hmsdsRespErr != nil && w.Code == http.StatusOK {
-			t.Errorf("Response code was %v; expected an error", w.Code)
+
+		if test.hmsdsRespErr != err {
+			t.Errorf("Request error was invalid, wanted '%v' and got '%v'", test.hmsdsRespErr, err)
 		}
 
-		if bytes.Compare(test.expectedResp, w.Body.Bytes()) != 0 {
+		if test.expectedStatus != w.Code {
+			t.Errorf("Response code was %v; expected an %v", w.Code, test.expectedStatus)
+		}
+
+		if !bytes.Equal(test.expectedResp, w.Body.Bytes()) {
 			t.Errorf("Test %v Failed: Expected body is '%v'; Received '%v'", i, string(test.expectedResp), w.Body)
 		}
 	}


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [X] My code follows the style guidelines of this project  
- [X] I have added/updated comments where needed  
- [X] I have added tests that prove my fix is effective or my feature works  
- [X] I have run `make test` (or equivalent) locally and all tests pass  
- [X] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [X] **REUSE Compliance**:  
  - [X] Each new/modified source file has SPDX copyright and license headers  
  - [X] Any non-commentable files include a `<filename>.license` sidecar  
  - [X] All referenced licenses are present in the `LICENSES/` directory  

### Description

Passes the `s.Logger` to the router.NotFound method instead of a function where it is instantiated but never used. 

Fixes #97

### Type of Change

- [X] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
