### PR TITLE
fix: remove appended index to component ID in `parseRedfishEndpointV2`

### DIFF
--- a/cmd/smd/smd-api.go
+++ b/cmd/smd/smd-api.go
@@ -3073,7 +3073,7 @@ func (s *SmD) parseRedfishEndpointDataV2(w http.ResponseWriter, data []byte, for
 
 			enabled := true
 			component := base.Component{
-				ID:      root.ID + fmt.Sprintf("n%d", ceNum),
+				ID:      root.ID 
 				NID:     nid,
 				State:   "On",
 				Type:    xnametypes.Node.String(),

--- a/cmd/smd/smd-api.go
+++ b/cmd/smd/smd-api.go
@@ -3073,7 +3073,7 @@ func (s *SmD) parseRedfishEndpointDataV2(w http.ResponseWriter, data []byte, for
 
 			enabled := true
 			component := base.Component{
-				ID:      root.ID 
+				ID:      root.ID,
 				NID:     nid,
 				State:   "On",
 				Type:    xnametypes.Node.String(),


### PR DESCRIPTION
…intDataV2

## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Description

This PR removes the append index value from the component ID created when using the `parseRedfishEndpointDataV2` function. This should allow for requests to include IDs that are submitted *as is* without any internal modifications from SMD.

Fixes #94 

### Type of Change

- [X] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
